### PR TITLE
2.2.0.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,14 @@ The changes for each individual (beta) release can be seen [here](https://github
 
 ## 2.1.9.0
 
+Sorry for the breaking changes, but they are worth it!
+
+- ⚠️ **Breaking** Removed `skipRescan` from `{device}/connect`. This is now always true.
+- ⚠️ **Breaking** The response formats of ``{device}/connect` and `{device}/disconnect` have changed. These now only return `Connected` or `Disconnected`.
+- Added `to` to `{device}/connect` to specify which device should be connected. If omitted, the currently selected device will be used. This is the behavior as it was in the previous versions.
+- Added `{device}/rescan` to rescan for new devices.
+- Added `{device}/list-available` to list all available devices.
+
 - Fixed an issue where the API would show the wrong ip address
 - Added the url parameter `save` to the `camera/capture` endpoint. This will save the image to the disk. This needs to be set, when capturing the image.
 - Added `sequence/state`, a new sequence endpoint for retrieving information that is much more elaborate and also supports plugins.

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,8 +2,9 @@
 
 The changes for each individual (beta) release can be seen [here](https://github.com/christian-photo/ninaAPI/releases). However this Changelog will be mostly complete.
 
-## 2.1.9.0
+## 2.2.0.0
 
+From now on, breaking changes will always increment the minor version number (the second number 2.x.0.0).
 Sorry for the breaking changes, but they are worth it!
 
 - ⚠️ **Breaking** Removed `skipRescan` from `{device}/connect`. This is now always true.

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,11 @@
 
 The changes for each individual (beta) release can be seen [here](https://github.com/christian-photo/ninaAPI/releases). However this Changelog will be mostly complete.
 
+## 2.1.9.0
+
+- Fixed an issue where the API would show the wrong ip address
+- Added `sequence/state`, a new sequence endpoint for retrieving information that is much more elaborate and also supports plugins
+
 ## 2.1.8.0
 
 - ⚠️ **Breaking** `image/{index}` now includes more images. Every image that is recieved as a websocket event can now be loaded using this endpoint. This is because the `imageType`

--- a/Changelog.md
+++ b/Changelog.md
@@ -16,7 +16,7 @@ Sorry for the breaking changes, but they are worth it!
 - Fixed an issue where the API would show the wrong ip address
 - Added the url parameter `save` to the `camera/capture` endpoint. This will save the image to the disk. This needs to be set, when capturing the image.
 - Added `sequence/state`, a new sequence endpoint for retrieving information that is much more elaborate and also supports plugins.
-- Added `sequence/edit`, which works similary to `profile/set-value`. Note that this mainly supports fields that expect simple types like strings, numbers etc, and may not work for things like enums or objects (filter, time source, ...). This is an experimental feature and may be unreliable or uncomplete.
+- Added `sequence/edit`, which works similary to `profile/set-value`. Note that this mainly supports fields that expect simple types like strings, numbers etc, and may not work for things like enums or objects (filter, time source, ...). This is an **experimental** feature and may be unreliable or uncomplete.
 - Added `mount/set-park-position`, which sets the current mount position as park position.
 
 ## 2.1.8.0

--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,8 @@ Sorry for the breaking changes, but they are worth it!
 - Added `{device}/rescan` to rescan for new devices.
 - Added `{device}/list-available` to list all available devices.
 
+---
+
 - Fixed an issue where the API would show the wrong ip address
 - Added the url parameter `save` to the `camera/capture` endpoint. This will save the image to the disk. This needs to be set, when capturing the image.
 - Added `sequence/state`, a new sequence endpoint for retrieving information that is much more elaborate and also supports plugins.

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,7 +5,10 @@ The changes for each individual (beta) release can be seen [here](https://github
 ## 2.1.9.0
 
 - Fixed an issue where the API would show the wrong ip address
-- Added `sequence/state`, a new sequence endpoint for retrieving information that is much more elaborate and also supports plugins
+- Added the url parameter `save` to the `camera/capture` endpoint. This will save the image to the disk. This needs to be set, when capturing the image.
+- Added `sequence/state`, a new sequence endpoint for retrieving information that is much more elaborate and also supports plugins.
+- Added `sequence/edit`, which works similary to `profile/set-value`. Note that this mainly supports fields that expect simple types like strings, numbers etc, and may not work for things like enums or objects (filter, time source, ...). This is an experimental feature and may be unreliable or uncomplete.
+- Added `mount/set-park-position`, which sets the current mount position as park position.
 
 ## 2.1.8.0
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -23,6 +23,7 @@ Sorry for the breaking changes, but they are worth it!
 - Added `mount/set-park-position`, which sets the current mount position as park position.
 - Added `pause-alignment` and `resume-alignment` to the TPPA WebSocket.
 - Added an option to create and cache thumbnails for images. This has to be enabled if you want to use the new thumbnail endpoint (`image/thumbnail`).
+- Introduced `camera/capture/statistics` which analyses the captured image and returns stats like HFR, Stars, Median, ...
 
 ## 2.1.8.0
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -15,12 +15,14 @@ Sorry for the breaking changes, but they are worth it!
 
 ---
 
+- ⚠️ **Breaking** The mount does not automatically stop the movement anymore when disconnecting. This was causing issues with PHD and the 2 second delay should be enough as a safety measure.
 - Fixed an issue where the API would show the wrong ip address
 - Added the url parameter `save` to the `camera/capture` endpoint. This will save the image to the disk. This needs to be set, when capturing the image.
 - Added `sequence/state`, a new sequence endpoint for retrieving information that is much more elaborate and also supports plugins.
 - Added `sequence/edit`, which works similary to `profile/set-value`. Note that this mainly supports fields that expect simple types like strings, numbers etc, and may not work for things like enums or objects (filter, time source, ...). This is an **experimental** feature and may be unreliable or uncomplete.
 - Added `mount/set-park-position`, which sets the current mount position as park position.
 - Added `pause-alignment` and `resume-alignment` to the TPPA WebSocket.
+- Added an option to create and cache thumbnails for images. This has to be enabled if you want to use the new thumbnail endpoint (`image/thumbnail`).
 
 ## 2.1.8.0
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -18,6 +18,7 @@ Sorry for the breaking changes, but they are worth it!
 - Added `sequence/state`, a new sequence endpoint for retrieving information that is much more elaborate and also supports plugins.
 - Added `sequence/edit`, which works similary to `profile/set-value`. Note that this mainly supports fields that expect simple types like strings, numbers etc, and may not work for things like enums or objects (filter, time source, ...). This is an **experimental** feature and may be unreliable or uncomplete.
 - Added `mount/set-park-position`, which sets the current mount position as park position.
+- Added `pause-alignment` and `resume-alignment` to the TPPA WebSocket.
 
 ## 2.1.8.0
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,17 @@ This plugin aims to be an all-around api for building your own custom tools and 
 
 Many thanks to tcpalmer and his [web session plugin](https://github.com/tcpalmer/nina.plugin.web/tree/main), from which I took a lot of inspiration (and a few code snippets). I want to thank everyone for creating issues, reporting bugs to me and requesting new features! It really helps me a lot while trying to continually improve the api. All that to say, feature requests, bug reports and all of these things are highly welcome!
 
+### Versioning
+
+The versioning of the api works as follows:
+
+- The first number is the major version, and it indicates the current version of the api. Right now it is `v2/api`. This means, that if a 3.x.x.x version is released, there will be a new url path `v3/api`.
+- The second number is the minor version. Here, breaking changes often occur, bigger features are released with an increase in this version number.
+- The third number is incremented for smaller feature updates and bug fixes.
+- The fourth number is incremented for small 'emergency' bug fixes.
+
 ---
 
 Looking for an app? Take a look at these projects:
 
-- https://github.com/Touch-N-Stars/Touch-N-Stars
+- [Touch'N'Stars: WebApp for Mobile Control of NINA](https://github.com/Touch-N-Stars/Touch-N-Stars)

--- a/ninaAPI/AdvancedAPI.cs
+++ b/ninaAPI/AdvancedAPI.cs
@@ -32,6 +32,8 @@ using NINA.Core.Utility;
 using NINA.Equipment.Interfaces;
 using NINA.Astrometry.Interfaces;
 using NINA.Core.Utility.WindowService;
+using System.IO;
+using System.Reflection;
 
 namespace ninaAPI
 {
@@ -136,6 +138,11 @@ namespace ninaAPI
 
             SetHostNames();
             API.StartWatchers();
+
+            if (Directory.Exists(Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "thumbnails")))
+            {
+                Directory.Delete(Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "thumbnails"), true);
+            }
         }
 
         public static int GetCachedPort()
@@ -197,6 +204,16 @@ namespace ninaAPI
                 Settings.Default.Port = value;
                 CoreUtil.SaveSettings(Settings.Default);
                 PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Port)));
+            }
+        }
+
+        public bool CreateThumbnails
+        {
+            get => Settings.Default.CreateThumbnails;
+            set
+            {
+                Settings.Default.CreateThumbnails = value;
+                CoreUtil.SaveSettings(Settings.Default);
             }
         }
 

--- a/ninaAPI/AdvancedAPI.cs
+++ b/ninaAPI/AdvancedAPI.cs
@@ -31,6 +31,7 @@ using System.Windows;
 using NINA.Core.Utility;
 using NINA.Equipment.Interfaces;
 using NINA.Astrometry.Interfaces;
+using NINA.Core.Utility.WindowService;
 
 namespace ninaAPI
 {
@@ -73,7 +74,8 @@ namespace ninaAPI
                            IMessageBroker broker,
                            IFramingAssistantVM framing,
                            IDomeFollower domeFollower,
-                           ITwilightCalculator twilightCalculator)
+                           ITwilightCalculator twilightCalculator,
+                           IWindowServiceFactory windowFactory)
         {
 
             PluginId = this.Identifier;
@@ -106,6 +108,7 @@ namespace ninaAPI
                 FramingAssistant = framing,
                 DomeFollower = domeFollower,
                 TwilightCalculator = twilightCalculator,
+                WindowFactory = windowFactory,
             };
 
             if (Settings.Default.UpdateSettings)

--- a/ninaAPI/NINAControls.cs
+++ b/ninaAPI/NINAControls.cs
@@ -10,6 +10,7 @@
 #endregion "copyright"
 
 using NINA.Astrometry.Interfaces;
+using NINA.Core.Utility.WindowService;
 using NINA.Equipment.Interfaces;
 using NINA.Equipment.Interfaces.Mediator;
 using NINA.Image.Interfaces;
@@ -57,6 +58,7 @@ namespace ninaAPI
         public IMessageBroker MessageBroker;
         public IFramingAssistantVM FramingAssistant;
         public ITwilightCalculator TwilightCalculator;
+        public IWindowServiceFactory WindowFactory;
         #endregion
     }
 }

--- a/ninaAPI/Options.xaml
+++ b/ninaAPI/Options.xaml
@@ -20,6 +20,13 @@
                     Text="API Enabled " />
                 <CheckBox IsChecked="{Binding APIEnabled}" />
             </StackPanel>
+            <StackPanel Orientation="Horizontal">
+                <TextBlock
+                    Width="100"
+                    Margin="0,0,5,0"
+                    Text="Create Thumbnails " />
+                <CheckBox IsChecked="{Binding CreateThumbnails}" />
+            </StackPanel>
             <!--<StackPanel Orientation="Horizontal">
                 <TextBlock
                     Width="100"

--- a/ninaAPI/Options.xaml
+++ b/ninaAPI/Options.xaml
@@ -16,14 +16,16 @@
             <StackPanel Orientation="Horizontal">
                 <TextBlock
                     Width="100"
-                    Margin="0,0,5,0"
+                    Margin="0,5,5,0"
                     Text="API Enabled " />
                 <CheckBox IsChecked="{Binding APIEnabled}" />
             </StackPanel>
+            <Separator Margin="30" />
+            <TextBlock Margin="10,5,0,10" Text="Be careful when changing any of the below options! These alter the functionaliy of the API, and can cause apps like Touch 'N' Stars to not work properly." />
             <StackPanel Orientation="Horizontal">
                 <TextBlock
-                    Width="100"
-                    Margin="0,0,5,0"
+                    Width="300"
+                    Margin="0,5,5,0"
                     Text="Create Thumbnails " />
                 <CheckBox IsChecked="{Binding CreateThumbnails}" />
             </StackPanel>
@@ -43,34 +45,30 @@
             </StackPanel>-->
             <StackPanel Margin="0,5,0,0" Orientation="Horizontal">
                 <TextBlock
-                    Width="100"
+                    Width="300"
                     Margin="0,0,5,0"
                     Text="API Port " />
                 <TextBox Width="100" Text="{Binding Port}" />
-                <TextBlock Margin="20,0,0,0" Text="API running on port: " Visibility="{Binding PortVisibility}" />
-                <TextBlock Text="{Binding CachedPort}" Visibility="{Binding PortVisibility}" />
+                <TextBlock Margin="20,5,0,0" Text="API running on port: " Visibility="{Binding PortVisibility}" />
+                <TextBlock Text="{Binding CachedPort}" Visibility="{Binding PortVisibility}" Margin="0,5,0,0" />
                 <Button Margin="10,0,0,0" Content="Update Default Port" Command="{Binding UpdateDefaultPortCommand}" Width="200" Visibility="{Binding PortVisibility}" ToolTip="This updates the port the api is launched on, meaning that the api will always launch on that port"/>
             </StackPanel>
-
-            <Separator Margin="30" />
 
             <StackPanel Orientation="Horizontal">
                 <TextBlock
                     Margin="0,0,5,0"
                     VerticalAlignment="Center"
                     Text="⚠️Use Access-Control-Allow-Origin Header⚠️"
+                    Width="300"
                     ToolTip="This makes it possible to fetch the api using javascript without having to set up a proxy. It is required for some applications like Touch 'N' Stars" />
                 <CheckBox IsChecked="{Binding UseAccessHeader}" />
             </StackPanel>
 
             <TextBlock Margin="0,5,0,0" Text="Access-Control-Allow-Origin is part of the CORS rules and determines which websites are allowed to access a server's data. Without this header, browsers block requests from other domains for security reasons. This is only relevant if the software is accessible via the Internet - in closed networks, such attacks from outside are not possible." />
 
-            <Separator
-                Width="20"
-                Height="10"
-                Background="Transparent" />
+            <Separator Margin="30" />
 
-            <StackPanel Margin="0,10,0,0" Orientation="Vertical">
+            <StackPanel Orientation="Vertical">
                 <TextBlock Margin="0,5,0,5" Text="Network adresses: " />
                 <StackPanel Orientation="Horizontal">
                     <TextBlock

--- a/ninaAPI/Properties/AssemblyInfo.cs
+++ b/ninaAPI/Properties/AssemblyInfo.cs
@@ -6,8 +6,8 @@ using System.Runtime.InteropServices;
 
 // [MANDATORY] The assembly versioning
 //Should be incremented for each new build of a plugin
-[assembly: AssemblyVersion("2.1.8.0")] // last one is for beta
-[assembly: AssemblyFileVersion("2.1.8.0")]
+[assembly: AssemblyVersion("2.1.9.0")] // last one is for beta
+[assembly: AssemblyFileVersion("2.1.9.0")]
 
 // [MANDATORY] The name of your plugin
 [assembly: AssemblyTitle("Advanced API")]

--- a/ninaAPI/Properties/AssemblyInfo.cs
+++ b/ninaAPI/Properties/AssemblyInfo.cs
@@ -6,8 +6,8 @@ using System.Runtime.InteropServices;
 
 // [MANDATORY] The assembly versioning
 //Should be incremented for each new build of a plugin
-[assembly: AssemblyVersion("2.1.9.0")] // last one is for beta
-[assembly: AssemblyFileVersion("2.1.9.0")]
+[assembly: AssemblyVersion("2.2.0.0")]
+[assembly: AssemblyFileVersion("2.2.0.0")]
 
 // [MANDATORY] The name of your plugin
 [assembly: AssemblyTitle("Advanced API")]

--- a/ninaAPI/Properties/Settings.Designer.cs
+++ b/ninaAPI/Properties/Settings.Designer.cs
@@ -130,5 +130,17 @@ namespace ninaAPI.Properties {
                 this["UseAccessControlHeader"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool CreateThumbnails {
+            get {
+                return ((bool)(this["CreateThumbnails"]));
+            }
+            set {
+                this["CreateThumbnails"] = value;
+            }
+        }
     }
 }

--- a/ninaAPI/Properties/Settings.settings
+++ b/ninaAPI/Properties/Settings.settings
@@ -29,5 +29,8 @@
     <Setting Name="UseAccessControlHeader" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="CreateThumbnails" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/ninaAPI/Utility/CoreUtility.cs
+++ b/ninaAPI/Utility/CoreUtility.cs
@@ -224,6 +224,10 @@ namespace ninaAPI.Utility
             }
             if (type.IsEnum)
             {
+                if (int.TryParse(str, out int x))
+                {
+                    return Enum.ToObject(type, x);
+                }
                 return Enum.Parse(type, str);
             }
             return str;
@@ -245,7 +249,7 @@ namespace ninaAPI.Utility
     public class SequenceIgnoreResolver : DefaultJsonTypeInfoResolver
     {
         private static readonly string[] ignoredProperties = { "UniversalPolarAlignmentVM", "Latitude", "Longitude", "Elevation", "AltitudeSite", "ShiftTrackingRate",
-            "DateTime", "Expanded", "DateTimeProviders" };
+            "DateTime", "Expanded", "DateTimeProviders", "Horizon" };
 
         private static readonly Type[] ignoredTypes = { typeof(IProfile), typeof(IProfileService), typeof(CustomHorizon), typeof(ICommand), typeof(AsyncRelayCommand), typeof(CommunityToolkit.Mvvm.Input.RelayCommand) };
 
@@ -257,7 +261,6 @@ namespace ninaAPI.Utility
             {
                 foreach (JsonPropertyInfo property in typeInfo.Properties)
                 {
-                    Logger.Debug($"Property {property.Name} is ignored");
                     if (ignoredProperties.Contains(property.Name) || ignoredTypes.Contains(property.PropertyType))
                     {
                         property.ShouldSerialize = (_, _) => false;

--- a/ninaAPI/Utility/CoreUtility.cs
+++ b/ninaAPI/Utility/CoreUtility.cs
@@ -249,7 +249,7 @@ namespace ninaAPI.Utility
     public class SequenceIgnoreResolver : DefaultJsonTypeInfoResolver
     {
         private static readonly string[] ignoredProperties = { "UniversalPolarAlignmentVM", "Latitude", "Longitude", "Elevation", "AltitudeSite", "ShiftTrackingRate",
-            "DateTime", "Expanded", "DateTimeProviders", "Horizon" };
+            "DateTime", "Expanded", "DateTimeProviders", "Horizon", "Parent" };
 
         private static readonly Type[] ignoredTypes = { typeof(IProfile), typeof(IProfileService), typeof(CustomHorizon), typeof(ICommand), typeof(AsyncRelayCommand), typeof(CommunityToolkit.Mvvm.Input.RelayCommand) };
 

--- a/ninaAPI/WebService/V2/Application/Application.cs
+++ b/ninaAPI/WebService/V2/Application/Application.cs
@@ -24,6 +24,7 @@ using System.Threading.Tasks;
 using System.Reflection;
 using System.Collections.Generic;
 using System.Linq;
+using NINA.Core.Utility.WindowService;
 
 namespace ninaAPI.WebService.V2
 {

--- a/ninaAPI/WebService/V2/Application/Flat.cs
+++ b/ninaAPI/WebService/V2/Application/Flat.cs
@@ -559,7 +559,7 @@ namespace ninaAPI.WebService.V2
             HttpResponse response = new HttpResponse();
             try
             {
-                response.Response = new FlatStatusResponse(flatTask);
+                response.Response = new FlatStatusResponse(container, flatTask);
             }
             catch (Exception ex)
             {
@@ -600,8 +600,10 @@ namespace ninaAPI.WebService.V2
     public struct FlatStatusResponse
     {
         public string State { get; }
+        public int TotalIterations { get; }
+        public int CompletedIterations { get; }
 
-        public FlatStatusResponse(Task task)
+        public FlatStatusResponse(SequentialContainer container, Task task)
         {
             if (task is not null)
             {
@@ -610,6 +612,18 @@ namespace ninaAPI.WebService.V2
             else
             {
                 State = "Finished";
+            }
+
+            if (State.Equals("Running"))
+            {
+                LoopCondition loop = (LoopCondition)container.GetType().GetMethod("GetIterations").Invoke(container, null);
+                TotalIterations = loop.Iterations;
+                CompletedIterations = loop.CompletedIterations;
+            }
+            else
+            {
+                TotalIterations = -1;
+                CompletedIterations = -1;
             }
         }
     }

--- a/ninaAPI/WebService/V2/Application/Flat.cs
+++ b/ninaAPI/WebService/V2/Application/Flat.cs
@@ -559,7 +559,7 @@ namespace ninaAPI.WebService.V2
             HttpResponse response = new HttpResponse();
             try
             {
-                response.Response = new FlatStatusResponse(container, flatTask);
+                response.Response = new FlatStatusResponse(flatTask);
             }
             catch (Exception ex)
             {
@@ -600,10 +600,8 @@ namespace ninaAPI.WebService.V2
     public struct FlatStatusResponse
     {
         public string State { get; }
-        public int TotalIterations { get; }
-        public int CompletedIterations { get; }
 
-        public FlatStatusResponse(SequentialContainer container, Task task)
+        public FlatStatusResponse(Task task)
         {
             if (task is not null)
             {
@@ -612,18 +610,6 @@ namespace ninaAPI.WebService.V2
             else
             {
                 State = "Finished";
-            }
-
-            if (State.Equals("Running"))
-            {
-                LoopCondition loop = (LoopCondition)container.GetType().GetMethod("GetIterations").Invoke(container, null);
-                TotalIterations = loop.Iterations;
-                CompletedIterations = loop.CompletedIterations;
-            }
-            else
-            {
-                TotalIterations = -1;
-                CompletedIterations = -1;
             }
         }
     }

--- a/ninaAPI/WebService/V2/Application/Sequence.cs
+++ b/ninaAPI/WebService/V2/Application/Sequence.cs
@@ -265,7 +265,7 @@ namespace ninaAPI.WebService.V2
 
         private static readonly string[] ignoredProperties = {
             "Name", "Status", "IsExpanded", "ErrorBehavior", "Attempts", "CoordsFromPlanetariumCommand", "ExposureInfoListExpanded", "CoordsToFramingCommand",
-            "DeleteExposureInfoCommand", "ExposureInfoList", "DateTimeProviders", "ImageTypes", "DropTargetCommand", "DateTime", "ProfileService" };
+            "DeleteExposureInfoCommand", "ExposureInfoList", "DateTimeProviders", "ImageTypes", "DropTargetCommand", "DateTime", "ProfileService", "Parent" };
 
         private static List<Hashtable> getSequenceRecursivleyNew(ISequenceContainer sequence)
         {

--- a/ninaAPI/WebService/V2/Application/Sequence.cs
+++ b/ninaAPI/WebService/V2/Application/Sequence.cs
@@ -131,6 +131,7 @@ namespace ninaAPI.WebService.V2
                         response.Response = json;
                     }
                 }
+                HttpContext.WriteSequenceResponse(response);
             }
             catch (Exception ex)
             {
@@ -138,7 +139,7 @@ namespace ninaAPI.WebService.V2
                 response = CoreUtility.CreateErrorTable(CommonErrors.UNKNOWN_ERROR);
             }
 
-            HttpContext.WriteSequenceResponse(response);
+
         }
 
         [Route(HttpVerbs.Get, "/sequence/edit")]
@@ -265,7 +266,7 @@ namespace ninaAPI.WebService.V2
 
         private static readonly string[] ignoredProperties = {
             "Name", "Status", "IsExpanded", "ErrorBehavior", "Attempts", "CoordsFromPlanetariumCommand", "ExposureInfoListExpanded", "CoordsToFramingCommand",
-            "DeleteExposureInfoCommand", "ExposureInfoList", "DateTimeProviders", "ImageTypes", "DropTargetCommand", "DateTime", "ProfileService", "Parent" };
+            "DeleteExposureInfoCommand", "ExposureInfoList", "DateTimeProviders", "ImageTypes", "DropTargetCommand", "DateTime", "ProfileService", "Parent", "InfoButtonColor", "Icon" };
 
         private static List<Hashtable> getSequenceRecursivleyNew(ISequenceContainer sequence)
         {

--- a/ninaAPI/WebService/V2/Equipment/Camera.cs
+++ b/ninaAPI/WebService/V2/Equipment/Camera.cs
@@ -180,58 +180,6 @@ namespace ninaAPI.WebService.V2
             HttpContext.WriteToResponse(response);
         }
 
-        [Route(HttpVerbs.Get, "/equipment/camera/connect")]
-        public async Task CameraConnect([QueryField] bool skipRescan)
-        {
-            HttpResponse response = new HttpResponse();
-
-            try
-            {
-                ICameraMediator cam = AdvancedAPI.Controls.Camera;
-
-                if (!cam.GetInfo().Connected)
-                {
-                    if (!skipRescan)
-                    {
-                        await cam.Rescan();
-                    }
-                    await cam.Connect();
-                }
-                response.Response = "Camera connected";
-            }
-            catch (Exception ex)
-            {
-                Logger.Error(ex);
-                response = CoreUtility.CreateErrorTable(CommonErrors.UNKNOWN_ERROR);
-            }
-
-            HttpContext.WriteToResponse(response);
-        }
-
-        [Route(HttpVerbs.Get, "/equipment/camera/disconnect")]
-        public async Task CameraDisconnect()
-        {
-            HttpResponse response = new HttpResponse();
-
-            try
-            {
-                ICameraMediator cam = AdvancedAPI.Controls.Camera;
-
-                if (cam.GetInfo().Connected)
-                {
-                    await cam.Disconnect();
-                }
-                response.Response = "Camera disconnected";
-            }
-            catch (Exception ex)
-            {
-                Logger.Error(ex);
-                response = CoreUtility.CreateErrorTable(CommonErrors.UNKNOWN_ERROR);
-            }
-
-            HttpContext.WriteToResponse(response);
-        }
-
         [Route(HttpVerbs.Get, "/equipment/camera/set-readout")]
         public void CameraSetReadout([QueryField] short mode)
         {

--- a/ninaAPI/WebService/V2/Equipment/Camera.cs
+++ b/ninaAPI/WebService/V2/Equipment/Camera.cs
@@ -144,9 +144,9 @@ namespace ninaAPI.WebService.V2
             AdvancedAPI.Controls.Camera.RemoveConsumer(this);
         }
 
-        public void UpdateDeviceInfo(CameraInfo deviceInfo)
+        public async void UpdateDeviceInfo(CameraInfo deviceInfo)
         {
-            WebSocketV2.SendConsumerEvent("CAMERA");
+            await WebSocketV2.SendConsumerEvent("CAMERA");
         }
     }
 

--- a/ninaAPI/WebService/V2/Equipment/Camera.cs
+++ b/ninaAPI/WebService/V2/Equipment/Camera.cs
@@ -472,7 +472,8 @@ namespace ninaAPI.WebService.V2
             [QueryField] double scale,
             [QueryField] bool stream,
             [QueryField] bool omitImage,
-            [QueryField] bool waitForResult)
+            [QueryField] bool waitForResult,
+            [QueryField] bool save)
         {
 
             HttpResponse response = new HttpResponse();
@@ -612,13 +613,17 @@ namespace ninaAPI.WebService.V2
                             IImageSolver captureSolver = platesolver.GetImageSolver(platesolver.GetPlateSolver(settings), platesolver.GetBlindSolver(settings));
                             plateSolveResult = await captureSolver.Solve(renderedImage.RawImageData, solverParameter, AdvancedAPI.Controls.StatusMediator.GetStatus(), CameraCaptureToken.Token);
                         }
+                        if (save)
+                        {
+                            await AdvancedAPI.Controls.ImageSaveMediator.Enqueue(renderedImage.RawImageData, Task.Run(() => renderedImage), AdvancedAPI.Controls.StatusMediator.GetStatus(), CameraCaptureToken.Token);
+                        }
                         await WebSocketV2.SendAndAddEvent("API-CAPTURE-FINISHED");
                     }, CameraCaptureToken.Token);
 
                     if (waitForResult)
                     {
                         await CaptureTask;
-                        await CameraCapture(false, 0, true, resize, quality, size, 0, scale, stream, omitImage, false);
+                        await CameraCapture(false, 0, true, resize, quality, size, 0, scale, stream, omitImage, false, false);
                         return;
                     }
                     response.Response = "Capture started";

--- a/ninaAPI/WebService/V2/Equipment/Connection.cs
+++ b/ninaAPI/WebService/V2/Equipment/Connection.cs
@@ -52,7 +52,7 @@ namespace ninaAPI.WebService.V2
                 }
                 else
                 {
-                    response = CoreUtility.CreateErrorTable(new Error("Invalid device", 400));
+                    response = CoreUtility.CreateErrorTable(new Error("Invalid equipment", 400));
                 }
             }
             catch (Exception ex)
@@ -102,7 +102,7 @@ namespace ninaAPI.WebService.V2
                 }
                 else
                 {
-                    response = CoreUtility.CreateErrorTable(new Error("Invalid device", 400));
+                    response = CoreUtility.CreateErrorTable(new Error("Invalid equipment", 400));
                 }
             }
             catch (Exception ex)
@@ -131,7 +131,7 @@ namespace ninaAPI.WebService.V2
                 }
                 else
                 {
-                    response = CoreUtility.CreateErrorTable(new Error("Invalid device", 400));
+                    response = CoreUtility.CreateErrorTable(new Error("Invalid equipment", 400));
                 }
             }
             catch (Exception ex)
@@ -162,7 +162,7 @@ namespace ninaAPI.WebService.V2
                 }
                 else
                 {
-                    response = CoreUtility.CreateErrorTable(new Error("Invalid device", 400));
+                    response = CoreUtility.CreateErrorTable(new Error("Invalid equipment", 400));
                 }
             }
             catch (Exception ex)

--- a/ninaAPI/WebService/V2/Equipment/Connection.cs
+++ b/ninaAPI/WebService/V2/Equipment/Connection.cs
@@ -29,8 +29,6 @@ using NINA.WPF.Base.ViewModel.Equipment.Telescope;
 using NINA.WPF.Base.ViewModel.Equipment.WeatherData;
 using ninaAPI.Utility;
 using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -38,135 +36,143 @@ namespace ninaAPI.WebService.V2
 {
     public partial class ControllerV2
     {
-        // [Route(HttpVerbs.Get, "/equipment/{device}/list-devices")]
-        // public void ListDevices(string device)
-        // {
-        //     HttpResponse response = new HttpResponse();
+        [Route(HttpVerbs.Get, "/equipment/{device}/list-devices")]
+        public void ListDevices(string device)
+        {
+            HttpResponse response = new HttpResponse();
 
-        //     try
-        //     {
-        //         var vms = GetDeviceVM(device);
-        //         IDeviceChooserVM chooser = vms.Item1;
+            try
+            {
+                var vms = GetDeviceVM(device);
+                IDeviceChooserVM chooser = vms.Item1;
 
-        //         if (chooser != null)
-        //         {
-        //             response.Response = chooser.Devices;
-        //         }
-        //         else
-        //         {
-        //             response = CoreUtility.CreateErrorTable(new Error("Invalid device", 400));
-        //         }
-        //     }
-        //     catch (Exception ex)
-        //     {
-        //         Logger.Error(ex);
-        //         response = CoreUtility.CreateErrorTable(CommonErrors.UNKNOWN_ERROR);
-        //     }
+                if (chooser != null)
+                {
+                    response.Response = chooser.Devices;
+                }
+                else
+                {
+                    response = CoreUtility.CreateErrorTable(new Error("Invalid device", 400));
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex);
+                response = CoreUtility.CreateErrorTable(CommonErrors.UNKNOWN_ERROR);
+            }
 
-        //     HttpContext.WriteToResponse(response);
-        // }
+            HttpContext.WriteToResponse(response);
+        }
 
-        // [Route(HttpVerbs.Get, "/equipment/{device}/connect")]
-        // public async Task DeviceConnect(string device, [QueryField] string to)
-        // {
-        //     HttpResponse response = new HttpResponse();
+        [Route(HttpVerbs.Get, "/equipment/{device}/connect")]
+        public async Task DeviceConnect(string device, [QueryField] string to)
+        {
+            HttpResponse response = new HttpResponse();
 
-        //     try
-        //     {
-        //         var vms = GetDeviceVM(device);
-        //         IDeviceChooserVM chooser = vms.Item1;
-        //         object handler = vms.Item2;
+            try
+            {
+                var vms = GetDeviceVM(device);
+                IDeviceChooserVM chooser = vms.Item1;
+                object handler = vms.Item2;
 
-        //         if (chooser != null)
-        //         {
-        //             IDevice d = chooser.Devices.First(x => x.Id == to);
-        //             if (d != null)
-        //             {
-        //                 chooser.SelectedDevice = d;
-        //                 bool success = await (Task<bool>)handler.GetType().GetMethod("Connect").Invoke(handler, []);
-        //                 response.Success = success;
-        //                 response.Response = success ? "Connected" : "";
-        //                 response.Error = success ? "" : "Failed to connect";
-        //                 response.StatusCode = success ? 200 : 400;
-        //             }
-        //             else
-        //             {
-        //                 response = CoreUtility.CreateErrorTable(new Error("Invalid Id", 400));
-        //             }
-        //         }
-        //         else
-        //         {
-        //             response = CoreUtility.CreateErrorTable(new Error("Invalid device", 400));
-        //         }
-        //     }
-        //     catch (Exception ex)
-        //     {
-        //         Logger.Error(ex);
-        //         response = CoreUtility.CreateErrorTable(CommonErrors.UNKNOWN_ERROR);
-        //     }
+                if (chooser != null)
+                {
+                    IDevice d;
+                    if (HttpContext.IsParameterOmitted(nameof(to)))
+                    {
+                        d = chooser.SelectedDevice;
+                    }
+                    else
+                    {
+                        d = chooser.Devices.First(x => x.Id == to);
+                    }
+                    if (d != null)
+                    {
+                        chooser.SelectedDevice = d;
+                        bool success = await (Task<bool>)handler.GetType().GetMethod("Connect").Invoke(handler, []);
+                        response.Success = success;
+                        response.Response = success ? "Connected" : "";
+                        response.Error = success ? "" : "Failed to connect";
+                        response.StatusCode = success ? 200 : 400;
+                    }
+                    else
+                    {
+                        response = CoreUtility.CreateErrorTable(new Error("Invalid Id", 400));
+                    }
+                }
+                else
+                {
+                    response = CoreUtility.CreateErrorTable(new Error("Invalid device", 400));
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex);
+                response = CoreUtility.CreateErrorTable(CommonErrors.UNKNOWN_ERROR);
+            }
 
-        //     HttpContext.WriteToResponse(response);
-        // }
+            HttpContext.WriteToResponse(response);
+        }
 
-        // [Route(HttpVerbs.Get, "/equipment/{device}/disconnect")]
-        // public async Task DeviceDisconnect(string device)
-        // {
-        //     HttpResponse response = new HttpResponse();
+        [Route(HttpVerbs.Get, "/equipment/{device}/disconnect")]
+        public async Task DeviceDisconnect(string device)
+        {
+            HttpResponse response = new HttpResponse();
 
-        //     try
-        //     {
-        //         var vms = GetDeviceVM(device);
-        //         object handler = vms.Item2;
+            try
+            {
+                var vms = GetDeviceVM(device);
+                object handler = vms.Item2;
 
-        //         if (handler != null)
-        //         {
-        //             await (Task)handler.GetType().GetMethod("Disconnect").Invoke(handler, []);
-        //             response.Response = "Disconnected";
-        //         }
-        //         else
-        //         {
-        //             response = CoreUtility.CreateErrorTable(new Error("Invalid device", 400));
-        //         }
-        //     }
-        //     catch (Exception ex)
-        //     {
-        //         Logger.Error(ex);
-        //         response = CoreUtility.CreateErrorTable(CommonErrors.UNKNOWN_ERROR);
-        //     }
+                if (handler != null)
+                {
+                    await (Task)handler.GetType().GetMethod("Disconnect").Invoke(handler, []);
+                    response.Response = "Disconnected";
+                }
+                else
+                {
+                    response = CoreUtility.CreateErrorTable(new Error("Invalid device", 400));
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex);
+                response = CoreUtility.CreateErrorTable(CommonErrors.UNKNOWN_ERROR);
+            }
 
-        //     HttpContext.WriteToResponse(response);
-        // }
+            HttpContext.WriteToResponse(response);
+        }
 
-        // [Route(HttpVerbs.Get, "/equipment/{device}/rescan")]
-        // public async Task DeviceRescan(string device)
-        // {
-        //     HttpResponse response = new HttpResponse();
+        [Route(HttpVerbs.Get, "/equipment/{device}/rescan")]
+        public async Task DeviceRescan(string device)
+        {
+            HttpResponse response = new HttpResponse();
 
-        //     try
-        //     {
-        //         var vms = GetDeviceVM(device);
-        //         IDeviceChooserVM chooser = vms.Item1;
-        //         object handler = vms.Item2;
+            try
+            {
+                var vms = GetDeviceVM(device);
+                IDeviceChooserVM chooser = vms.Item1;
+                object handler = vms.Item2;
 
-        //         if (handler != null)
-        //         {
-        //             var command = (AsyncCommand<bool>)handler.GetType().GetProperty("RescanDevicesCommand", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance).GetValue(handler);
-        //             await command.ExecuteAsync(null);
-        //             response.Response = chooser.Devices;
-        //         }
-        //         else
-        //         {
-        //             response = CoreUtility.CreateErrorTable(new Error("Invalid device", 400));
-        //         }
-        //     }
-        //     catch (Exception ex)
-        //     {
-        //         Logger.Error(ex);
-        //         response = CoreUtility.CreateErrorTable(CommonErrors.UNKNOWN_ERROR);
-        //     }
+                if (handler != null)
+                {
+                    var command = (AsyncCommand<bool>)handler.GetType().GetProperty("RescanDevicesCommand", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance).GetValue(handler);
+                    await command.ExecuteAsync(null);
+                    response.Response = chooser.Devices;
+                }
+                else
+                {
+                    response = CoreUtility.CreateErrorTable(new Error("Invalid device", 400));
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex);
+                response = CoreUtility.CreateErrorTable(CommonErrors.UNKNOWN_ERROR);
+            }
 
-        //     HttpContext.WriteToResponse(response);
-        // }
+            HttpContext.WriteToResponse(response);
+        }
 
         private (IDeviceChooserVM, object) GetDeviceVM(string device)
         {

--- a/ninaAPI/WebService/V2/Equipment/Connection.cs
+++ b/ninaAPI/WebService/V2/Equipment/Connection.cs
@@ -9,6 +9,7 @@
 
 #endregion "copyright"
 
+using CommunityToolkit.Mvvm.Input;
 using EmbedIO;
 using EmbedIO.Routing;
 using EmbedIO.WebApi;
@@ -156,9 +157,17 @@ namespace ninaAPI.WebService.V2
 
                 if (handler != null)
                 {
-                    var command = (AsyncCommand<bool>)handler.GetType().GetProperty("RescanDevicesCommand", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance).GetValue(handler);
-                    await command.ExecuteAsync(null);
-                    response.Response = chooser.Devices;
+                    var command = handler.GetType().GetProperty("RescanDevicesCommand", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance).GetValue(handler);
+                    if (command is AsyncCommand<bool> cmd)
+                    {
+                        await cmd.ExecuteAsync(null);
+                        response.Response = chooser.Devices;
+                    }
+                    else
+                    {
+                        await ((AsyncRelayCommand<bool>)command).ExecuteAsync(null);
+                        response.Response = chooser.Devices;
+                    }
                 }
                 else
                 {

--- a/ninaAPI/WebService/V2/Equipment/Connection.cs
+++ b/ninaAPI/WebService/V2/Equipment/Connection.cs
@@ -1,0 +1,236 @@
+#region "copyright"
+
+/*
+    Copyright © 2025 Christian Palm (christian@palm-family.de)
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using EmbedIO;
+using EmbedIO.Routing;
+using EmbedIO.WebApi;
+using NINA.Core.Utility;
+using NINA.Equipment.Interfaces;
+using NINA.Equipment.Interfaces.ViewModel;
+using NINA.WPF.Base.Mediator;
+using NINA.WPF.Base.ViewModel.Equipment.Camera;
+using NINA.WPF.Base.ViewModel.Equipment.Dome;
+using NINA.WPF.Base.ViewModel.Equipment.FilterWheel;
+using NINA.WPF.Base.ViewModel.Equipment.FlatDevice;
+using NINA.WPF.Base.ViewModel.Equipment.Focuser;
+using NINA.WPF.Base.ViewModel.Equipment.Guider;
+using NINA.WPF.Base.ViewModel.Equipment.Rotator;
+using NINA.WPF.Base.ViewModel.Equipment.SafetyMonitor;
+using NINA.WPF.Base.ViewModel.Equipment.Switch;
+using NINA.WPF.Base.ViewModel.Equipment.Telescope;
+using NINA.WPF.Base.ViewModel.Equipment.WeatherData;
+using ninaAPI.Utility;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace ninaAPI.WebService.V2
+{
+    public partial class ControllerV2
+    {
+        // [Route(HttpVerbs.Get, "/equipment/{device}/list-devices")]
+        // public void ListDevices(string device)
+        // {
+        //     HttpResponse response = new HttpResponse();
+
+        //     try
+        //     {
+        //         var vms = GetDeviceVM(device);
+        //         IDeviceChooserVM chooser = vms.Item1;
+
+        //         if (chooser != null)
+        //         {
+        //             response.Response = chooser.Devices;
+        //         }
+        //         else
+        //         {
+        //             response = CoreUtility.CreateErrorTable(new Error("Invalid device", 400));
+        //         }
+        //     }
+        //     catch (Exception ex)
+        //     {
+        //         Logger.Error(ex);
+        //         response = CoreUtility.CreateErrorTable(CommonErrors.UNKNOWN_ERROR);
+        //     }
+
+        //     HttpContext.WriteToResponse(response);
+        // }
+
+        // [Route(HttpVerbs.Get, "/equipment/{device}/connect")]
+        // public async Task DeviceConnect(string device, [QueryField] string to)
+        // {
+        //     HttpResponse response = new HttpResponse();
+
+        //     try
+        //     {
+        //         var vms = GetDeviceVM(device);
+        //         IDeviceChooserVM chooser = vms.Item1;
+        //         object handler = vms.Item2;
+
+        //         if (chooser != null)
+        //         {
+        //             IDevice d = chooser.Devices.First(x => x.Id == to);
+        //             if (d != null)
+        //             {
+        //                 chooser.SelectedDevice = d;
+        //                 bool success = await (Task<bool>)handler.GetType().GetMethod("Connect").Invoke(handler, []);
+        //                 response.Success = success;
+        //                 response.Response = success ? "Connected" : "";
+        //                 response.Error = success ? "" : "Failed to connect";
+        //                 response.StatusCode = success ? 200 : 400;
+        //             }
+        //             else
+        //             {
+        //                 response = CoreUtility.CreateErrorTable(new Error("Invalid Id", 400));
+        //             }
+        //         }
+        //         else
+        //         {
+        //             response = CoreUtility.CreateErrorTable(new Error("Invalid device", 400));
+        //         }
+        //     }
+        //     catch (Exception ex)
+        //     {
+        //         Logger.Error(ex);
+        //         response = CoreUtility.CreateErrorTable(CommonErrors.UNKNOWN_ERROR);
+        //     }
+
+        //     HttpContext.WriteToResponse(response);
+        // }
+
+        // [Route(HttpVerbs.Get, "/equipment/{device}/disconnect")]
+        // public async Task DeviceDisconnect(string device)
+        // {
+        //     HttpResponse response = new HttpResponse();
+
+        //     try
+        //     {
+        //         var vms = GetDeviceVM(device);
+        //         object handler = vms.Item2;
+
+        //         if (handler != null)
+        //         {
+        //             await (Task)handler.GetType().GetMethod("Disconnect").Invoke(handler, []);
+        //             response.Response = "Disconnected";
+        //         }
+        //         else
+        //         {
+        //             response = CoreUtility.CreateErrorTable(new Error("Invalid device", 400));
+        //         }
+        //     }
+        //     catch (Exception ex)
+        //     {
+        //         Logger.Error(ex);
+        //         response = CoreUtility.CreateErrorTable(CommonErrors.UNKNOWN_ERROR);
+        //     }
+
+        //     HttpContext.WriteToResponse(response);
+        // }
+
+        // [Route(HttpVerbs.Get, "/equipment/{device}/rescan")]
+        // public async Task DeviceRescan(string device)
+        // {
+        //     HttpResponse response = new HttpResponse();
+
+        //     try
+        //     {
+        //         var vms = GetDeviceVM(device);
+        //         IDeviceChooserVM chooser = vms.Item1;
+        //         object handler = vms.Item2;
+
+        //         if (handler != null)
+        //         {
+        //             var command = (AsyncCommand<bool>)handler.GetType().GetProperty("RescanDevicesCommand", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance).GetValue(handler);
+        //             await command.ExecuteAsync(null);
+        //             response.Response = chooser.Devices;
+        //         }
+        //         else
+        //         {
+        //             response = CoreUtility.CreateErrorTable(new Error("Invalid device", 400));
+        //         }
+        //     }
+        //     catch (Exception ex)
+        //     {
+        //         Logger.Error(ex);
+        //         response = CoreUtility.CreateErrorTable(CommonErrors.UNKNOWN_ERROR);
+        //     }
+
+        //     HttpContext.WriteToResponse(response);
+        // }
+
+        private (IDeviceChooserVM, object) GetDeviceVM(string device)
+        {
+            IDeviceChooserVM chooser = null;
+            object handler = null;
+            switch (device)
+            {
+                case "camera":
+                    var cam = (CameraVM)typeof(CameraMediator).GetField("handler", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance).GetValue(AdvancedAPI.Controls.Camera);
+                    chooser = cam.DeviceChooserVM;
+                    handler = cam;
+                    break;
+                case "dome":
+                    var dome = (DomeVM)typeof(DomeMediator).GetField("handler", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance).GetValue(AdvancedAPI.Controls.Dome);
+                    chooser = dome.DeviceChooserVM;
+                    handler = dome;
+                    break;
+                case "filterwheel":
+                    var fw = (FilterWheelVM)typeof(FilterWheelMediator).GetField("handler", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance).GetValue(AdvancedAPI.Controls.FilterWheel);
+                    chooser = fw.DeviceChooserVM;
+                    handler = fw;
+                    break;
+                case "flatdevice":
+                    var fd = (FlatDeviceVM)typeof(FlatDeviceMediator).GetField("handler", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance).GetValue(AdvancedAPI.Controls.FlatDevice);
+                    chooser = fd.DeviceChooserVM;
+                    handler = fd;
+                    break;
+                case "focuser":
+                    var focuser = (FocuserVM)typeof(FocuserMediator).GetField("handler", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance).GetValue(AdvancedAPI.Controls.Focuser);
+                    chooser = focuser.DeviceChooserVM;
+                    handler = focuser;
+                    break;
+                case "guider":
+                    var guider = (GuiderVM)typeof(GuiderMediator).GetField("handler", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance).GetValue(AdvancedAPI.Controls.Guider);
+                    chooser = guider.DeviceChooserVM;
+                    handler = guider;
+                    break;
+                case "mount":
+                    var mount = (TelescopeVM)typeof(TelescopeMediator).GetField("handler", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance).GetValue(AdvancedAPI.Controls.Mount);
+                    chooser = mount.DeviceChooserVM;
+                    handler = mount;
+                    break;
+                case "rotator":
+                    var rotator = (RotatorVM)typeof(RotatorMediator).GetField("handler", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance).GetValue(AdvancedAPI.Controls.Rotator);
+                    chooser = rotator.DeviceChooserVM;
+                    handler = rotator;
+                    break;
+                case "safetymonitor":
+                    var sf = (SafetyMonitorVM)typeof(SafetyMonitorMediator).GetField("handler", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance).GetValue(AdvancedAPI.Controls.SafetyMonitor);
+                    chooser = sf.DeviceChooserVM;
+                    handler = sf;
+                    break;
+                case "switch":
+                    var swit = (SwitchVM)typeof(SwitchMediator).GetField("handler", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance).GetValue(AdvancedAPI.Controls.Switch);
+                    chooser = swit.DeviceChooserVM;
+                    handler = swit;
+                    break;
+                case "weather":
+                    var weather = (WeatherDataVM)typeof(WeatherDataMediator).GetField("handler", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance).GetValue(AdvancedAPI.Controls.Weather);
+                    chooser = weather.DeviceChooserVM;
+                    handler = weather;
+                    break;
+            }
+            return (chooser, handler);
+        }
+    }
+}

--- a/ninaAPI/WebService/V2/Equipment/Dome.cs
+++ b/ninaAPI/WebService/V2/Equipment/Dome.cs
@@ -103,58 +103,6 @@ namespace ninaAPI.WebService.V2
             HttpContext.WriteToResponse(response);
         }
 
-        [Route(HttpVerbs.Get, "/equipment/dome/connect")]
-        public async Task DomeConnect([QueryField] bool skipRescan)
-        {
-            HttpResponse response = new HttpResponse();
-
-            try
-            {
-                IDomeMediator dome = AdvancedAPI.Controls.Dome;
-
-                if (!dome.GetInfo().Connected)
-                {
-                    if (!skipRescan)
-                    {
-                        await dome.Rescan();
-                    }
-                    await dome.Connect();
-                }
-                response.Response = "Dome connected";
-            }
-            catch (Exception ex)
-            {
-                Logger.Error(ex);
-                response = CoreUtility.CreateErrorTable(CommonErrors.UNKNOWN_ERROR);
-            }
-
-            HttpContext.WriteToResponse(response);
-        }
-
-        [Route(HttpVerbs.Get, "/equipment/dome/disconnect")]
-        public async Task DomeDisconnect()
-        {
-            HttpResponse response = new HttpResponse();
-
-            try
-            {
-                IDomeMediator dome = AdvancedAPI.Controls.Dome;
-
-                if (dome.GetInfo().Connected)
-                {
-                    await dome.Disconnect();
-                }
-                response.Response = "Dome disconnected";
-            }
-            catch (Exception ex)
-            {
-                Logger.Error(ex);
-                response = CoreUtility.CreateErrorTable(CommonErrors.UNKNOWN_ERROR);
-            }
-
-            HttpContext.WriteToResponse(response);
-        }
-
         [Route(HttpVerbs.Get, "/equipment/dome/open")]
         public void DomeOpen()
         {

--- a/ninaAPI/WebService/V2/Equipment/Dome.cs
+++ b/ninaAPI/WebService/V2/Equipment/Dome.cs
@@ -70,9 +70,9 @@ namespace ninaAPI.WebService.V2
             AdvancedAPI.Controls.Dome.RemoveConsumer(this);
         }
 
-        public void UpdateDeviceInfo(DomeInfo deviceInfo)
+        public async void UpdateDeviceInfo(DomeInfo deviceInfo)
         {
-            WebSocketV2.SendConsumerEvent("DOME");
+            await WebSocketV2.SendConsumerEvent("DOME");
         }
     }
 

--- a/ninaAPI/WebService/V2/Equipment/FilterWheel.cs
+++ b/ninaAPI/WebService/V2/Equipment/FilterWheel.cs
@@ -99,9 +99,9 @@ namespace ninaAPI.WebService.V2
             AdvancedAPI.Controls.FilterWheel.RemoveConsumer(this);
         }
 
-        public void UpdateDeviceInfo(FilterWheelInfo deviceInfo)
+        public async void UpdateDeviceInfo(FilterWheelInfo deviceInfo)
         {
-            WebSocketV2.SendConsumerEvent("FILTERWHEEL");
+            await WebSocketV2.SendConsumerEvent("FILTERWHEEL");
         }
     }
 

--- a/ninaAPI/WebService/V2/Equipment/FilterWheel.cs
+++ b/ninaAPI/WebService/V2/Equipment/FilterWheel.cs
@@ -131,59 +131,6 @@ namespace ninaAPI.WebService.V2
             HttpContext.WriteToResponse(response);
         }
 
-        [Route(HttpVerbs.Get, "/equipment/filterwheel/connect")]
-        public async Task FilterWheelConnect([QueryField] bool skipRescan)
-        {
-            HttpResponse response = new HttpResponse();
-
-            try
-            {
-                IFilterWheelMediator filterwheel = AdvancedAPI.Controls.FilterWheel;
-
-                if (!filterwheel.GetInfo().Connected)
-                {
-                    if (!skipRescan)
-                    {
-                        await filterwheel.Rescan();
-                    }
-                    await filterwheel.Connect();
-
-                    response.Response = "Filterwheel connected";
-                }
-            }
-            catch (Exception ex)
-            {
-                Logger.Error(ex);
-                response = CoreUtility.CreateErrorTable(CommonErrors.UNKNOWN_ERROR);
-            }
-
-            HttpContext.WriteToResponse(response);
-        }
-
-        [Route(HttpVerbs.Get, "/equipment/filterwheel/disconnect")]
-        public async Task FilterWheelDisconnect()
-        {
-            HttpResponse response = new HttpResponse();
-
-            try
-            {
-                IFilterWheelMediator filterwheel = AdvancedAPI.Controls.FilterWheel;
-
-                if (filterwheel.GetInfo().Connected)
-                {
-                    await filterwheel.Disconnect();
-                }
-                response.Response = "Filterwheel disconnected";
-            }
-            catch (Exception ex)
-            {
-                Logger.Error(ex);
-                response = CoreUtility.CreateErrorTable(CommonErrors.UNKNOWN_ERROR);
-            }
-
-            HttpContext.WriteToResponse(response);
-        }
-
         [Route(HttpVerbs.Get, "/equipment/filterwheel/change-filter")]
         public void FilterWheelChangeFilter([QueryField] int filterId)
         {

--- a/ninaAPI/WebService/V2/Equipment/FlatDevice.cs
+++ b/ninaAPI/WebService/V2/Equipment/FlatDevice.cs
@@ -91,58 +91,6 @@ namespace ninaAPI.WebService.V2
             HttpContext.WriteToResponse(response);
         }
 
-        [Route(HttpVerbs.Get, "/equipment/flatdevice/connect")]
-        public async Task FlatDeviceConnect([QueryField] bool skipRescan)
-        {
-            HttpResponse response = new HttpResponse();
-
-            try
-            {
-                IFlatDeviceMediator flat = AdvancedAPI.Controls.FlatDevice;
-
-                if (!flat.GetInfo().Connected)
-                {
-                    if (!skipRescan)
-                    {
-                        await flat.Rescan();
-                    }
-                    await flat.Connect();
-                }
-                response.Response = "Flatdevice connected";
-            }
-            catch (Exception ex)
-            {
-                Logger.Error(ex);
-                response = CoreUtility.CreateErrorTable(CommonErrors.UNKNOWN_ERROR);
-            }
-
-            HttpContext.WriteToResponse(response);
-        }
-
-        [Route(HttpVerbs.Get, "/equipment/flatdevice/disconnect")]
-        public async Task FlatDeviceDisconnect()
-        {
-            HttpResponse response = new HttpResponse();
-
-            try
-            {
-                IFlatDeviceMediator flat = AdvancedAPI.Controls.FlatDevice;
-
-                if (flat.GetInfo().Connected)
-                {
-                    await flat.Disconnect();
-                }
-                response.Response = "Flatdevice disconnected";
-            }
-            catch (Exception ex)
-            {
-                Logger.Error(ex);
-                response = CoreUtility.CreateErrorTable(CommonErrors.UNKNOWN_ERROR);
-            }
-
-            HttpContext.WriteToResponse(response);
-        }
-
         [Route(HttpVerbs.Get, "/equipment/flatdevice/set-light")]
         public void FlatDeviceToggle([QueryField] bool on)
         {

--- a/ninaAPI/WebService/V2/Equipment/FlatDevice.cs
+++ b/ninaAPI/WebService/V2/Equipment/FlatDevice.cs
@@ -62,9 +62,9 @@ namespace ninaAPI.WebService.V2
             AdvancedAPI.Controls.FlatDevice.RemoveConsumer(this);
         }
 
-        public void UpdateDeviceInfo(FlatDeviceInfo deviceInfo)
+        public async void UpdateDeviceInfo(FlatDeviceInfo deviceInfo)
         {
-            WebSocketV2.SendConsumerEvent("FLATDEVICE");
+            await WebSocketV2.SendConsumerEvent("FLATDEVICE");
         }
     }
 

--- a/ninaAPI/WebService/V2/Equipment/Focuser.cs
+++ b/ninaAPI/WebService/V2/Equipment/Focuser.cs
@@ -50,19 +50,19 @@ namespace ninaAPI.WebService.V2
             AdvancedAPI.Controls.Focuser.RemoveConsumer(this);
         }
 
-        public void UpdateDeviceInfo(FocuserInfo deviceInfo)
+        public async void UpdateDeviceInfo(FocuserInfo deviceInfo)
         {
-            WebSocketV2.SendConsumerEvent("FOCUSER");
+            await WebSocketV2.SendConsumerEvent("FOCUSER");
         }
 
-        public void UpdateEndAutoFocusRun(AutoFocusInfo info)
+        public async void UpdateEndAutoFocusRun(AutoFocusInfo info)
         {
-            WebSocketV2.SendAndAddEvent("AUTOFOCUS-FINISHED");
+            await WebSocketV2.SendAndAddEvent("AUTOFOCUS-FINISHED");
         }
 
-        public void UpdateUserFocused(FocuserInfo info)
+        public async void UpdateUserFocused(FocuserInfo info)
         {
-            WebSocketV2.SendAndAddEvent("FOCUSER-USER-FOCUSED");
+            await WebSocketV2.SendAndAddEvent("FOCUSER-USER-FOCUSED");
         }
     }
 
@@ -204,7 +204,7 @@ namespace ninaAPI.WebService.V2
         }
 
         [Route(HttpVerbs.Get, "/equipment/focuser/last-af")]
-        public void FocuserLastAF()
+        public async Task FocuserLastAF()
         {
             HttpResponse response = new HttpResponse();
 
@@ -217,7 +217,8 @@ namespace ninaAPI.WebService.V2
                     if (files.Length > 0)
                     {
                         string newest = files.OrderBy(File.GetCreationTime).Last();
-                        response.Response = JsonConvert.DeserializeObject<AutoFocusReport>(File.ReadAllText(newest));
+                        string json = await Retry.Do(() => File.ReadAllText(newest), TimeSpan.FromMilliseconds(100), 5);
+                        response.Response = JsonConvert.DeserializeObject<AutoFocusReport>(json);
                     }
                     else
                     {

--- a/ninaAPI/WebService/V2/Equipment/Focuser.cs
+++ b/ninaAPI/WebService/V2/Equipment/Focuser.cs
@@ -89,56 +89,6 @@ namespace ninaAPI.WebService.V2
             HttpContext.WriteToResponse(response);
         }
 
-        [Route(HttpVerbs.Get, "/equipment/focuser/connect")]
-        public async Task FocuserConnect([QueryField] bool skipRescan)
-        {
-            HttpResponse response = new HttpResponse();
-
-            try
-            {
-                IFocuserMediator focuser = AdvancedAPI.Controls.Focuser;
-                if (!focuser.GetInfo().Connected)
-                {
-                    if (!skipRescan)
-                    {
-                        await focuser.Rescan();
-                    }
-                    await focuser.Connect();
-                }
-                response.Response = "Focuser connected";
-            }
-            catch (Exception ex)
-            {
-                Logger.Error(ex);
-                response = CoreUtility.CreateErrorTable(CommonErrors.UNKNOWN_ERROR);
-            }
-
-            HttpContext.WriteToResponse(response);
-        }
-
-        [Route(HttpVerbs.Get, "/equipment/focuser/disconnect")]
-        public async Task FocuserDisconnect()
-        {
-            HttpResponse response = new HttpResponse();
-
-            try
-            {
-                IFocuserMediator focuser = AdvancedAPI.Controls.Focuser;
-                if (focuser.GetInfo().Connected)
-                {
-                    await focuser.Disconnect();
-                }
-                response.Response = "Focuser disconnected";
-            }
-            catch (Exception ex)
-            {
-                Logger.Error(ex);
-                response = CoreUtility.CreateErrorTable(CommonErrors.UNKNOWN_ERROR);
-            }
-
-            HttpContext.WriteToResponse(response);
-        }
-
         [Route(HttpVerbs.Get, "/equipment/focuser/move")]
         public void FocuserMove([QueryField] int position)
         {

--- a/ninaAPI/WebService/V2/Equipment/Guider.cs
+++ b/ninaAPI/WebService/V2/Equipment/Guider.cs
@@ -116,9 +116,9 @@ namespace ninaAPI.WebService.V2
             AdvancedAPI.Controls.Guider.RemoveConsumer(this);
         }
 
-        public void UpdateDeviceInfo(GuiderInfo deviceInfo)
+        public async void UpdateDeviceInfo(GuiderInfo deviceInfo)
         {
-            WebSocketV2.SendConsumerEvent("GUIDER");
+            await WebSocketV2.SendConsumerEvent("GUIDER");
         }
 
         public void Dispose()

--- a/ninaAPI/WebService/V2/Equipment/Guider.cs
+++ b/ninaAPI/WebService/V2/Equipment/Guider.cs
@@ -154,58 +154,6 @@ namespace ninaAPI.WebService.V2
             HttpContext.WriteToResponse(response);
         }
 
-        [Route(HttpVerbs.Get, "/equipment/guider/connect")]
-        public async Task GuiderConnect([QueryField] bool skipRescan)
-        {
-            HttpResponse response = new HttpResponse();
-
-            try
-            {
-                IGuiderMediator guider = AdvancedAPI.Controls.Guider;
-
-                if (!guider.GetInfo().Connected)
-                {
-                    if (!skipRescan)
-                    {
-                        await guider.Rescan();
-                    }
-                    await guider.Connect();
-                }
-                response.Response = "Guider connected";
-            }
-            catch (Exception ex)
-            {
-                Logger.Error(ex);
-                response = CoreUtility.CreateErrorTable(CommonErrors.UNKNOWN_ERROR);
-            }
-
-            HttpContext.WriteToResponse(response);
-        }
-
-        [Route(HttpVerbs.Get, "/equipment/guider/disconnect")]
-        public async Task GuiderDisconnect()
-        {
-            HttpResponse response = new HttpResponse();
-
-            try
-            {
-                IGuiderMediator guider = AdvancedAPI.Controls.Guider;
-
-                if (guider.GetInfo().Connected)
-                {
-                    await guider.Disconnect();
-                }
-                response.Response = "Guider disconnected";
-            }
-            catch (Exception ex)
-            {
-                Logger.Error(ex);
-                response = CoreUtility.CreateErrorTable(CommonErrors.UNKNOWN_ERROR);
-            }
-
-            HttpContext.WriteToResponse(response);
-        }
-
         [Route(HttpVerbs.Get, "/equipment/guider/start")]
         public async Task GuiderStart([QueryField] bool calibrate)
         {

--- a/ninaAPI/WebService/V2/Equipment/Mount.cs
+++ b/ninaAPI/WebService/V2/Equipment/Mount.cs
@@ -96,58 +96,6 @@ namespace ninaAPI.WebService.V2
             HttpContext.WriteToResponse(response);
         }
 
-        [Route(HttpVerbs.Get, "/equipment/mount/connect")]
-        public async Task MountConnect([QueryField] bool skipRescan)
-        {
-            HttpResponse response = new HttpResponse();
-
-            try
-            {
-                ITelescopeMediator mount = AdvancedAPI.Controls.Mount;
-
-                if (!mount.GetInfo().Connected)
-                {
-                    if (!skipRescan)
-                    {
-                        await mount.Rescan();
-                    }
-                    await mount.Connect();
-                }
-                response.Response = "Mount connected";
-            }
-            catch (Exception ex)
-            {
-                Logger.Error(ex);
-                response = CoreUtility.CreateErrorTable(CommonErrors.UNKNOWN_ERROR);
-            }
-
-            HttpContext.WriteToResponse(response);
-        }
-
-        [Route(HttpVerbs.Get, "/equipment/mount/disconnect")]
-        public async Task MountDisconnect()
-        {
-            HttpResponse response = new HttpResponse();
-
-            try
-            {
-                ITelescopeMediator mount = AdvancedAPI.Controls.Mount;
-
-                if (mount.GetInfo().Connected)
-                {
-                    await mount.Disconnect();
-                }
-                response.Response = "Mount disconnected";
-            }
-            catch (Exception ex)
-            {
-                Logger.Error(ex);
-                response = CoreUtility.CreateErrorTable(CommonErrors.UNKNOWN_ERROR);
-            }
-
-            HttpContext.WriteToResponse(response);
-        }
-
         [Route(HttpVerbs.Get, "/equipment/mount/home")]
         public void MountHome()
         {

--- a/ninaAPI/WebService/V2/Equipment/Mount.cs
+++ b/ninaAPI/WebService/V2/Equipment/Mount.cs
@@ -67,9 +67,9 @@ namespace ninaAPI.WebService.V2
             AdvancedAPI.Controls.Mount.RemoveConsumer(this);
         }
 
-        public void UpdateDeviceInfo(TelescopeInfo deviceInfo)
+        public async void UpdateDeviceInfo(TelescopeInfo deviceInfo)
         {
-            WebSocketV2.SendConsumerEvent("MOUNT");
+            await WebSocketV2.SendConsumerEvent("MOUNT");
         }
     }
 

--- a/ninaAPI/WebService/V2/Equipment/Mount.cs
+++ b/ninaAPI/WebService/V2/Equipment/Mount.cs
@@ -546,19 +546,5 @@ namespace ninaAPI.WebService.V2
             }
             await context.WebSocket.SendAsync(Encoding.GetBytes(JsonSerializer.Serialize(response)), true);
         }
-
-        protected override Task OnClientDisconnectedAsync(IWebSocketContext context)
-        {
-            AdvancedAPI.Controls.Mount.MoveAxis(TelescopeAxes.Primary, 0);
-            AdvancedAPI.Controls.Mount.MoveAxis(TelescopeAxes.Secondary, 0);
-            return base.OnClientDisconnectedAsync(context);
-        }
-
-        protected override void Dispose(bool disposing)
-        {
-            AdvancedAPI.Controls.Mount.MoveAxis(TelescopeAxes.Primary, 0);
-            AdvancedAPI.Controls.Mount.MoveAxis(TelescopeAxes.Secondary, 0);
-            base.Dispose(disposing);
-        }
     }
 }

--- a/ninaAPI/WebService/V2/Equipment/Rotator.cs
+++ b/ninaAPI/WebService/V2/Equipment/Rotator.cs
@@ -78,58 +78,6 @@ namespace ninaAPI.WebService.V2
             HttpContext.WriteToResponse(response);
         }
 
-        [Route(HttpVerbs.Get, "/equipment/rotator/connect")]
-        public async Task RotatorConnect([QueryField] bool skipRescan)
-        {
-            HttpResponse response = new HttpResponse();
-
-            try
-            {
-                IRotatorMediator rotator = AdvancedAPI.Controls.Rotator;
-
-                if (!rotator.GetInfo().Connected)
-                {
-                    if (!skipRescan)
-                    {
-                        await rotator.Rescan();
-                    }
-                    await rotator.Connect();
-                }
-                response.Response = "Rotator connected";
-            }
-            catch (Exception ex)
-            {
-                Logger.Error(ex);
-                response = CoreUtility.CreateErrorTable(CommonErrors.UNKNOWN_ERROR);
-            }
-
-            HttpContext.WriteToResponse(response);
-        }
-
-        [Route(HttpVerbs.Get, "/equipment/rotator/disconnect")]
-        public async Task RotatorDisconnect()
-        {
-            HttpResponse response = new HttpResponse();
-
-            try
-            {
-                IRotatorMediator rotator = AdvancedAPI.Controls.Rotator;
-
-                if (rotator.GetInfo().Connected)
-                {
-                    await rotator.Disconnect();
-                }
-                response.Response = "Rotator disconnected";
-            }
-            catch (Exception ex)
-            {
-                Logger.Error(ex);
-                response = CoreUtility.CreateErrorTable(CommonErrors.UNKNOWN_ERROR);
-            }
-
-            HttpContext.WriteToResponse(response);
-        }
-
         [Route(HttpVerbs.Get, "/equipment/rotator/move")]
         public void RotatorMove([QueryField] float position)
         {

--- a/ninaAPI/WebService/V2/Equipment/Rotator.cs
+++ b/ninaAPI/WebService/V2/Equipment/Rotator.cs
@@ -46,9 +46,9 @@ namespace ninaAPI.WebService.V2
             AdvancedAPI.Controls.Rotator.RemoveConsumer(this);
         }
 
-        public void UpdateDeviceInfo(RotatorInfo deviceInfo)
+        public async void UpdateDeviceInfo(RotatorInfo deviceInfo)
         {
-            WebSocketV2.SendConsumerEvent("ROTATOR");
+            await WebSocketV2.SendConsumerEvent("ROTATOR");
         }
     }
 

--- a/ninaAPI/WebService/V2/Equipment/SafetyMonitor.cs
+++ b/ninaAPI/WebService/V2/Equipment/SafetyMonitor.cs
@@ -68,57 +68,5 @@ namespace ninaAPI.WebService.V2
 
             HttpContext.WriteToResponse(response);
         }
-
-        [Route(HttpVerbs.Get, "/equipment/safetymonitor/connect")]
-        public async Task SafetyMonitorConnect([QueryField] bool skipRescan)
-        {
-            HttpResponse response = new HttpResponse();
-
-            try
-            {
-                ISafetyMonitorMediator safetymonitor = AdvancedAPI.Controls.SafetyMonitor;
-
-                if (!safetymonitor.GetInfo().Connected)
-                {
-                    if (!skipRescan)
-                    {
-                        await safetymonitor.Rescan();
-                    }
-                    await safetymonitor.Connect();
-                }
-                response.Response = "Safetymonitor connected";
-            }
-            catch (Exception ex)
-            {
-                Logger.Error(ex);
-                response = CoreUtility.CreateErrorTable(CommonErrors.UNKNOWN_ERROR);
-            }
-
-            HttpContext.WriteToResponse(response);
-        }
-
-        [Route(HttpVerbs.Get, "/equipment/safetymonitor/disconnect")]
-        public async Task SafetyMonitorDisconnect()
-        {
-            HttpResponse response = new HttpResponse();
-
-            try
-            {
-                ISafetyMonitorMediator safetymonitor = AdvancedAPI.Controls.SafetyMonitor;
-
-                if (safetymonitor.GetInfo().Connected)
-                {
-                    await safetymonitor.Disconnect();
-                }
-                response.Response = "Safetymonitor disconnected";
-            }
-            catch (Exception ex)
-            {
-                Logger.Error(ex);
-                response = CoreUtility.CreateErrorTable(CommonErrors.UNKNOWN_ERROR);
-            }
-
-            HttpContext.WriteToResponse(response);
-        }
     }
 }

--- a/ninaAPI/WebService/V2/Equipment/Switch.cs
+++ b/ninaAPI/WebService/V2/Equipment/Switch.cs
@@ -77,58 +77,6 @@ namespace ninaAPI.WebService.V2
             HttpContext.WriteToResponse(response);
         }
 
-        [Route(HttpVerbs.Get, "/equipment/switch/connect")]
-        public async Task SwitchConnect([QueryField] bool skipRescan)
-        {
-            HttpResponse response = new HttpResponse();
-
-            try
-            {
-                ISwitchMediator sw = AdvancedAPI.Controls.Switch;
-
-                if (!sw.GetInfo().Connected)
-                {
-                    if (!skipRescan)
-                    {
-                        await sw.Rescan();
-                    }
-                    await sw.Connect();
-                }
-                response.Response = "Switch connected";
-            }
-            catch (Exception ex)
-            {
-                Logger.Error(ex);
-                response = CoreUtility.CreateErrorTable(CommonErrors.UNKNOWN_ERROR);
-            }
-
-            HttpContext.WriteToResponse(response);
-        }
-
-        [Route(HttpVerbs.Get, "/equipment/switch/disconnect")]
-        public async Task SwitchDisconnect()
-        {
-            HttpResponse response = new HttpResponse();
-
-            try
-            {
-                ISwitchMediator sw = AdvancedAPI.Controls.Switch;
-
-                if (sw.GetInfo().Connected)
-                {
-                    await sw.Disconnect();
-                }
-                response.Response = "Switch disconnected";
-            }
-            catch (Exception ex)
-            {
-                Logger.Error(ex);
-                response = CoreUtility.CreateErrorTable(CommonErrors.UNKNOWN_ERROR);
-            }
-
-            HttpContext.WriteToResponse(response);
-        }
-
         [Route(HttpVerbs.Get, "/equipment/switch/set")]
         public void SwitchSet([QueryField] short index, [QueryField] double value)
         {

--- a/ninaAPI/WebService/V2/Equipment/Switch.cs
+++ b/ninaAPI/WebService/V2/Equipment/Switch.cs
@@ -46,9 +46,9 @@ namespace ninaAPI.WebService.V2
             AdvancedAPI.Controls.Switch.RemoveConsumer(this);
         }
 
-        public void UpdateDeviceInfo(SwitchInfo deviceInfo)
+        public async void UpdateDeviceInfo(SwitchInfo deviceInfo)
         {
-            WebSocketV2.SendConsumerEvent("SWITCH");
+            await WebSocketV2.SendConsumerEvent("SWITCH");
         }
     }
 

--- a/ninaAPI/WebService/V2/Equipment/Weather.cs
+++ b/ninaAPI/WebService/V2/Equipment/Weather.cs
@@ -11,7 +11,6 @@
 
 using EmbedIO;
 using EmbedIO.Routing;
-using EmbedIO.WebApi;
 using NINA.Core.Utility;
 using NINA.Equipment.Equipment.MyWeatherData;
 using NINA.Equipment.Interfaces.Mediator;
@@ -64,58 +63,6 @@ namespace ninaAPI.WebService.V2
 
                 WeatherDataInfo info = Weather.GetInfo();
                 response.Response = info;
-            }
-            catch (Exception ex)
-            {
-                Logger.Error(ex);
-                response = CoreUtility.CreateErrorTable(CommonErrors.UNKNOWN_ERROR);
-            }
-
-            HttpContext.WriteToResponse(response);
-        }
-
-        [Route(HttpVerbs.Get, "/equipment/weather/connect")]
-        public async Task WeatherConnect([QueryField] bool skipRescan)
-        {
-            HttpResponse response = new HttpResponse();
-
-            try
-            {
-                IWeatherDataMediator weather = AdvancedAPI.Controls.Weather;
-
-                if (!weather.GetInfo().Connected)
-                {
-                    if (!skipRescan)
-                    {
-                        await weather.Rescan();
-                    }
-                    await weather.Connect();
-                }
-                response.Response = "Weather connected";
-            }
-            catch (Exception ex)
-            {
-                Logger.Error(ex);
-                response = CoreUtility.CreateErrorTable(CommonErrors.UNKNOWN_ERROR);
-            }
-
-            HttpContext.WriteToResponse(response);
-        }
-
-        [Route(HttpVerbs.Get, "/equipment/weather/disconnect")]
-        public async Task WeatherDisconnect()
-        {
-            HttpResponse response = new HttpResponse();
-
-            try
-            {
-                IWeatherDataMediator weather = AdvancedAPI.Controls.Weather;
-
-                if (weather.GetInfo().Connected)
-                {
-                    await weather.Disconnect();
-                }
-                response.Response = "Weather disconnected";
             }
             catch (Exception ex)
             {

--- a/ninaAPI/WebService/V2/Equipment/Weather.cs
+++ b/ninaAPI/WebService/V2/Equipment/Weather.cs
@@ -45,9 +45,9 @@ namespace ninaAPI.WebService.V2
             AdvancedAPI.Controls.Weather.RemoveConsumer(this);
         }
 
-        public void UpdateDeviceInfo(WeatherDataInfo deviceInfo)
+        public async void UpdateDeviceInfo(WeatherDataInfo deviceInfo)
         {
-            WebSocketV2.SendConsumerEvent("WEATHER");
+            await WebSocketV2.SendConsumerEvent("WEATHER");
         }
     }
 

--- a/ninaAPI/WebService/V2/TPPASocket.cs
+++ b/ninaAPI/WebService/V2/TPPASocket.cs
@@ -32,17 +32,27 @@ namespace ninaAPI.WebService.V2
         {
             string message = Encoding.GetString(rxBuffer); // Do something with it
             string topic;
-            bool started;
+            string response;
 
             if (message.Equals("start-alignment"))
             {
                 topic = "PolarAlignmentPlugin_DockablePolarAlignmentVM_StartAlignment";
-                started = true;
+                response = "started procedure";
             }
             else if (message.Equals("stop-alignment"))
             {
                 topic = "PolarAlignmentPlugin_DockablePolarAlignmentVM_StopAlignment";
-                started = false;
+                response = "stopped procedure";
+            }
+            else if (message.Equals("pause-alignment"))
+            {
+                topic = "PolarAlignmentPlugin_PolarAlignment_PauseAlignment";
+                response = "paused procedure";
+            }
+            else if (message.Equals("resume-alignment"))
+            {
+                topic = "PolarAlignmentPlugin_PolarAlignment_ResumeAlignment";
+                response = "resumed procedure";
             }
             else
             {
@@ -54,7 +64,7 @@ namespace ninaAPI.WebService.V2
             await Send(new HttpResponse()
             {
                 Type = HttpResponse.TypeSocket,
-                Response = started ? "started procedure" : "stopped procedure"
+                Response = response
             });
         }
 
@@ -90,9 +100,9 @@ namespace ninaAPI.WebService.V2
                     Type = HttpResponse.TypeSocket,
                     Response = new Dictionary<string, double>
                     {
-                        { nameof(AzimuthError), AzimuthError },
-                        { nameof(AltitudeError), AltitudeError },
-                        { nameof(TotalError), TotalError },
+                        { "AzimuthError", AzimuthError },
+                        { "AltitudeError", AltitudeError },
+                        { "TotalError", TotalError },
                     }
                 });
             }

--- a/ninaAPI/api_spec.yaml
+++ b/ninaAPI/api_spec.yaml
@@ -637,6 +637,12 @@ paths:
           required: false
           schema:
             type: boolean
+        - in: query
+          name: save
+          description: Save the image to the disk. This needs to be set, when capturing the image.
+          required: false
+          schema:
+            type: boolean
       responses:
         "200":
           description: Successful response
@@ -2818,6 +2824,67 @@ paths:
               schema:
                 $ref: "#/components/schemas/UnknownError"
 
+  /equipment/mount/set-park-position:
+    get:
+      tags:
+        - Mount
+      summary: Set Park Position
+      description: Sets the current mount position as park position. This requires the mount to be unparked.
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  Response:
+                    type: string
+                    example: "Park position set"
+                  Error:
+                    type: string
+                    example: ""
+                  StatusCode:
+                    type: integer
+                    example: 200
+                  Success:
+                    type: boolean
+                    example: true
+                  Type:
+                    type: string
+                    example: "API"
+        "400":
+          description: Can't update park position
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  Response:
+                    type: string
+                    example: ""
+                  Error:
+                    type: string
+                    enum:
+                      - Mount not connected
+                      - Mount can not set park position
+                      - Park position update failed
+                  StatusCode:
+                    type: integer
+                    example: 400
+                  Success:
+                    type: boolean
+                    example: false
+                  Type:
+                    type: string
+                    example: "API"
+        "500":
+          description: Internal server error, Unknown error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnknownError"
+
   /equipment/rotator/info:
     get:
       tags:
@@ -4486,6 +4553,71 @@ paths:
                   StatusCode:
                     type: integer
                     example: 409
+                  Success:
+                    type: boolean
+                    example: false
+                  Type:
+                    type: string
+                    example: "API"
+        "500":
+          description: Internal server error, Unknown error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnknownError"
+
+  /sequence/edit:
+    get:
+      tags:
+        - Sequence
+      summary: Edit a Sequence
+      description: 
+        This which works similary to profile/set-value. Note that this mainly supports fields that expect simple types like strings, numbers etc, 
+        and may not work for things like enums or objects (filter, time source, ...). This is an experimental feature, and it could have unexpected side effects or simply not work for some instructions or fields.
+        If you encounter any bugs (except that it is not working with enums or objects), feel free to create an issue on github or contact me on the NINA discord.
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  Response:
+                    type: string
+                    example: Updated setting
+                  Error:
+                    type: string
+                    example: ""
+                  StatusCode:
+                    type: integer
+                    example: 200
+                  Success:
+                    type: boolean
+                    example: true
+                  Type:
+                    type: string
+                    example: "API"
+        "400":
+          description: Faulty state
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  Response:
+                    type: string
+                    example: ""
+                  Error:
+                    type: string
+                    enum:
+                      - Sequence is not initialized
+                      - No DSO Container found
+                      - Invalid path
+                      - New value can't be null
+                  StatusCode:
+                    type: integer
+                    example: 400
                   Success:
                     type: boolean
                     example: false

--- a/ninaAPI/api_spec.yaml
+++ b/ninaAPI/api_spec.yaml
@@ -791,6 +791,77 @@ paths:
               schema:
                 $ref: "#/components/schemas/UnknownError"
 
+  /equipment/camera/capture/statistics:
+    get:
+      tags:
+        - Camera
+      summary: Capture Statistics
+      description: This endpoint returns the image statistics for the last captured image.
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  Response:
+                    type: object
+                    properties:
+                      Stars:
+                        type: integer
+                      HFR:
+                        type: number
+                      Median:
+                        type: number
+                      MedianAbsoluteDeviation:
+                        type: number
+                      Mean:
+                        type: number
+                      Max:
+                        type: integer
+                      Min:
+                        type: integer
+                      StDev:
+                        type: number
+                  Error:
+                    type: string
+                  StatusCode:
+                    type: integer
+                  Success:
+                    type: boolean
+                  Type:
+                    type: string
+
+        "400":
+          description: Capture not available
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  Response:
+                    type: string
+                    example: "No image available"
+                  Error:
+                    type: string
+                    example: ""
+                  StatusCode:
+                    type: integer
+                    example: 409
+                  Success:
+                    type: boolean
+                    example: false
+                  Type:
+                    type: string
+                    example: "API"
+        "500":
+          description: Internal server error, Unknown error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnknownError"
+
   /equipment/dome/info:
     get:
       tags:

--- a/ninaAPI/api_spec.yaml
+++ b/ninaAPI/api_spec.yaml
@@ -4738,6 +4738,70 @@ paths:
               schema:
                 $ref: "#/components/schemas/UnknownError"
 
+  /image/thumbnail/{index}:
+    get:
+      tags:
+        - Image
+      summary: Get Thumbnail
+      description: Get the thumbnail of an image. This requies Create Thumbnails to be enabled in NINA. Otherwise, use the image endpoint and resize the image. This thumbnail has a width of 256px.
+      parameters:
+        - in: path
+          name: index
+          description: The index of the image to get
+          required: true
+          schema:
+            type: integer
+            format: int32
+        - in: query
+          name: imageType
+          description: Filter the image history by image type. This is useful if you got the index of an image using the history with a filter and now want to get the image. E.g. the 3rd flat in the image history is the 3rd flat in the image endpoint.
+          required: false
+          schema:
+            type: string
+            enum:
+              - LIGHT
+              - FLAT
+              - DARK
+              - BIAS
+              - SNAPSHOT
+      responses:
+        "200":
+          description: Successful response
+          content:
+            image/jpg:
+              schema:
+                description: Image in jpg format, when stream is set to true and the image quality is specified
+                type: array
+                format: binary
+        "400":
+          description: No thumbnails available
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  Response:
+                    type: string
+                    example: ""
+                  Error:
+                    type: string
+                    example: "No thumbnails available"
+                  StatusCode:
+                    type: integer
+                    example: 400
+                  Success:
+                    type: boolean
+                    example: false
+                  Type:
+                    type: string
+                    example: "API"
+        "500":
+          description: Internal server error, Unknown error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnknownError"
+
   /profile/show:
     get:
       tags:

--- a/ninaAPI/api_spec.yaml
+++ b/ninaAPI/api_spec.yaml
@@ -1,8 +1,8 @@
 openapi: 3.0.0
 info:
   title: Advanced API
-  description: This is the API documentation for the NINA plugin Advanced API. This documentation applies to plugin version 2.1.9.*
-  version: 2.1.9
+  description: This is the API documentation for the NINA plugin Advanced API. This documentation applies to plugin version 2.2.0.*
+  version: 2.2.0
 servers:
   - url: http://localhost:1888/v2/api
     description: V2 api server
@@ -23,7 +23,7 @@ paths:
                 properties:
                   Response:
                     type: string
-                    example: 2.1.9.0
+                    example: 2.2.0.0
                   Error:
                     type: string
                     example: ""

--- a/ninaAPI/api_spec.yaml
+++ b/ninaAPI/api_spec.yaml
@@ -4453,6 +4453,52 @@ paths:
               schema:
                 $ref: "#/components/schemas/UnknownError"
 
+  /sequence/state:
+    get:
+      tags:
+        - Sequence
+      summary: Complete Sequence
+      description:
+        Get sequence as json. For this to work, there needs to be a deep sky object container present and the sequencer view has to be initalized! This is similar to the json endpoint, however the
+        returned sequence is much more elaborate and also supports plugins. The returned json from /json is not directly compatible with this endpoint.
+      responses:
+        "200":
+          description: Successful response, best to try it out yourself
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SequenceBaseJson"
+        "409":
+          description: Sequencer not initialized / No DSO container found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  Response:
+                    type: string
+                    example: ""
+                  Error:
+                    type: string
+                    enum:
+                      - Sequencer not initialized
+                      - No DSO container found
+                  StatusCode:
+                    type: integer
+                    example: 409
+                  Success:
+                    type: boolean
+                    example: false
+                  Type:
+                    type: string
+                    example: "API"
+        "500":
+          description: Internal server error, Unknown error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnknownError"
+
   /sequence/start:
     get:
       tags:

--- a/ninaAPI/api_spec.yaml
+++ b/ninaAPI/api_spec.yaml
@@ -5666,10 +5666,19 @@ paths:
                 type: object
                 properties:
                   Response:
-                    type: string
-                    enum:
-                      - Running
-                      - Finished
+                    type: object
+                    properties:
+                      CompletedIterations:
+                        type: integer
+                        example: 10
+                      TotalIterations:
+                        type: integer
+                        example: 15
+                      State:
+                        type: string
+                        enum:
+                          - Running
+                          - Finished
                   Error:
                     type: string
                     example: ""

--- a/ninaAPI/api_spec.yaml
+++ b/ninaAPI/api_spec.yaml
@@ -4956,7 +4956,7 @@ paths:
       summary: Complete Sequence
       description:
         Get sequence as json. For this to work, there needs to be a deep sky object container present and the sequencer view has to be initalized! This is similar to the json endpoint, however the
-        returned sequence is much more elaborate and also supports plugins. The returned json from /json is not directly compatible with this endpoint.
+        returned sequence is much more elaborate and also supports plugins. The returned json from /json is not directly compatible with this endpoint. Use this endpoint (not json!) as reference for sequence editing!
       responses:
         "200":
           description: Successful response, best to try it out yourself
@@ -5001,9 +5001,28 @@ paths:
         - Sequence
       summary: Edit a Sequence
       description:
-        This which works similary to profile/set-value. Note that this mainly supports fields that expect simple types like strings, numbers etc,
+        This works similary to profile/set-value. Note that this mainly supports fields that expect simple types like strings, numbers etc,
         and may not work for things like enums or objects (filter, time source, ...). This is an experimental feature, and it could have unexpected side effects or simply not work for some instructions or fields.
         If you encounter any bugs (except that it is not working with enums or objects), feel free to create an issue on github or contact me on the NINA discord.
+      parameters:
+        - in: query
+          name: path
+          description:
+            The path to the property that should be updated. Use `GlobalTriggers`, `Start`, `Imaging`, `End` for the sequence root containers.
+            Then use the name of the property or the index of the item in a list, seperated with `-`.
+            The example would set the exposure time of a Take Exposure instruction, contained in a DSO container, to 20s.
+            Use `sequence/state` as reference, not `sequence/json`!
+          required: true
+          schema:
+            type: string
+            example: "Imaging-Items-0-Items-0-ExposureTime"
+        - in: query
+          name: value
+          description: The new value
+          required: true
+          schema:
+            type: string
+            example: "20"
       responses:
         "200":
           description: Successful response

--- a/ninaAPI/api_spec.yaml
+++ b/ninaAPI/api_spec.yaml
@@ -1,8 +1,8 @@
 openapi: 3.0.0
 info:
   title: Advanced API
-  description: This is the API documentation for the NINA plugin Advanced API. This documentation applies to plugin version 2.1.8.*
-  version: 2.1.8
+  description: This is the API documentation for the NINA plugin Advanced API. This documentation applies to plugin version 2.1.9.*
+  version: 2.1.9
 servers:
   - url: http://localhost:1888/v2/api
     description: V2 api server
@@ -23,7 +23,7 @@ paths:
                 properties:
                   Response:
                     type: string
-                    example: 2.1.8.0
+                    example: 2.1.9.0
                   Error:
                     type: string
                     example: ""
@@ -65,12 +65,11 @@ paths:
       description: Connect to Camera
       parameters:
         - in: query
-          name: skipRescan
+          name: to
           required: false
-          description: Indicates if rescan should be skipped
+          description: The Id of the device that should be connected.
           schema:
-            type: boolean
-            default: false
+            type: string
       responses:
         "200":
           description: Successful response
@@ -81,7 +80,7 @@ paths:
                 properties:
                   Response:
                     type: string
-                    example: Camera connected
+                    example: Connected
                   Error:
                     type: string
                     example: ""
@@ -117,7 +116,7 @@ paths:
                 properties:
                   Response:
                     type: string
-                    example: Camera disconnected
+                    example: Disconnected
                   Error:
                     type: string
                     example: ""
@@ -130,6 +129,46 @@ paths:
                   Type:
                     type: string
                     example: "API"
+        "500":
+          description: Internal server error, Unknown error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnknownError"
+
+  /equipment/camera/list-devices:
+    get:
+      tags:
+        - Camera
+      summary: List Devices
+      description: List all devices which can be connected
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeviceList"
+        "500":
+          description: Internal server error, Unknown error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnknownError"
+
+  /equipment/camera/rescan:
+    get:
+      tags:
+        - Camera
+      summary: Rescan Devices
+      description: Rescans for new devices, and returns a list of all available devices
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeviceList"
         "500":
           description: Internal server error, Unknown error
           content:
@@ -780,12 +819,11 @@ paths:
       description: Connect to Dome
       parameters:
         - in: query
-          name: skipRescan
+          name: to
           required: false
-          description: Indicates if rescan should be skipped
+          description: The Id of the device that should be connected.
           schema:
-            type: boolean
-            default: false
+            type: string
       responses:
         "200":
           description: Successful response
@@ -796,7 +834,7 @@ paths:
                 properties:
                   Response:
                     type: string
-                    example: Dome connected
+                    example: Connected
                   Error:
                     type: string
                     example: ""
@@ -832,7 +870,7 @@ paths:
                 properties:
                   Response:
                     type: string
-                    example: Dome disconnected
+                    example: Disconnected
                   Error:
                     type: string
                     example: ""
@@ -845,6 +883,46 @@ paths:
                   Type:
                     type: string
                     example: "API"
+        "500":
+          description: Internal server error, Unknown error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnknownError"
+
+  /equipment/dome/list-devices:
+    get:
+      tags:
+        - Dome
+      summary: List Devices
+      description: List all devices which can be connected
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeviceList"
+        "500":
+          description: Internal server error, Unknown error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnknownError"
+
+  /equipment/dome/rescan:
+    get:
+      tags:
+        - Dome
+      summary: Rescan Devices
+      description: Rescans for new devices, and returns a list of all available devices
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeviceList"
         "500":
           description: Internal server error, Unknown error
           content:
@@ -1243,12 +1321,11 @@ paths:
       description: Connect to Filterwheel
       parameters:
         - in: query
-          name: skipRescan
+          name: to
           required: false
-          description: Indicates if rescan should be skipped
+          description: The Id of the device that should be connected.
           schema:
-            type: boolean
-            default: false
+            type: string
       responses:
         "200":
           description: Successful response
@@ -1259,7 +1336,7 @@ paths:
                 properties:
                   Response:
                     type: string
-                    example: Filterwheel connected
+                    example: Connected
                   Error:
                     type: string
                     example: ""
@@ -1295,7 +1372,7 @@ paths:
                 properties:
                   Response:
                     type: string
-                    example: Filterwheel disconnected
+                    example: Disconnected
                   Error:
                     type: string
                     example: ""
@@ -1308,6 +1385,46 @@ paths:
                   Type:
                     type: string
                     example: "API"
+        "500":
+          description: Internal server error, Unknown error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnknownError"
+
+  /equipment/filterwheel/list-devices:
+    get:
+      tags:
+        - FilterWheel
+      summary: List Devices
+      description: List all devices which can be connected
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeviceList"
+        "500":
+          description: Internal server error, Unknown error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnknownError"
+
+  /equipment/filterwheel/rescan:
+    get:
+      tags:
+        - FilterWheel
+      summary: Rescan Devices
+      description: Rescans for new devices, and returns a list of all available devices
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeviceList"
         "500":
           description: Internal server error, Unknown error
           content:
@@ -1461,12 +1578,11 @@ paths:
       description: Connect the flat panel
       parameters:
         - in: query
-          name: skipRescan
+          name: to
           required: false
-          description: Indicates if rescan should be skipped
+          description: The Id of the device that should be connected.
           schema:
-            type: boolean
-            default: false
+            type: string
       responses:
         "200":
           description: Successful response
@@ -1477,7 +1593,7 @@ paths:
                 properties:
                   Response:
                     type: string
-                    example: Flatdevice connected
+                    example: Connected
                   Error:
                     type: string
                     example: ""
@@ -1513,7 +1629,7 @@ paths:
                 properties:
                   Response:
                     type: string
-                    example: Flatdevice disconnected
+                    example: Disconnected
                   Error:
                     type: string
                     example: ""
@@ -1526,6 +1642,46 @@ paths:
                   Type:
                     type: string
                     example: "API"
+        "500":
+          description: Internal server error, Unknown error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnknownError"
+
+  /equipment/flatdevice/list-devices:
+    get:
+      tags:
+        - Flat Panel
+      summary: List Devices
+      description: List all devices which can be connected
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeviceList"
+        "500":
+          description: Internal server error, Unknown error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnknownError"
+
+  /equipment/flatdevice/rescan:
+    get:
+      tags:
+        - Flat Panel
+      summary: Rescan Devices
+      description: Rescans for new devices, and returns a list of all available devices
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeviceList"
         "500":
           description: Internal server error, Unknown error
           content:
@@ -1762,12 +1918,11 @@ paths:
       description: Connect to Focuser
       parameters:
         - in: query
-          name: skipRescan
+          name: to
           required: false
-          description: Indicates if rescan should be skipped
+          description: The Id of the device that should be connected.
           schema:
-            type: boolean
-            default: false
+            type: string
       responses:
         "200":
           description: Successful response
@@ -1778,7 +1933,7 @@ paths:
                 properties:
                   Response:
                     type: string
-                    example: Focuser connected
+                    example: Connected
                   Error:
                     type: string
                     example: ""
@@ -1814,7 +1969,7 @@ paths:
                 properties:
                   Response:
                     type: string
-                    example: Focuser disconnected
+                    example: Disconnected
                   Error:
                     type: string
                     example: ""
@@ -1827,6 +1982,46 @@ paths:
                   Type:
                     type: string
                     example: "API"
+        "500":
+          description: Internal server error, Unknown error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnknownError"
+
+  /equipment/focuser/list-devices:
+    get:
+      tags:
+        - Focuser
+      summary: List Devices
+      description: List all devices which can be connected
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeviceList"
+        "500":
+          description: Internal server error, Unknown error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnknownError"
+
+  /equipment/focuser/rescan:
+    get:
+      tags:
+        - Focuser
+      summary: Rescan Devices
+      description: Rescans for new devices, and returns a list of all available devices
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeviceList"
         "500":
           description: Internal server error, Unknown error
           content:
@@ -1992,12 +2187,11 @@ paths:
       description: Connect to Guider
       parameters:
         - in: query
-          name: skipRescan
+          name: to
           required: false
-          description: Indicates if rescan should be skipped
+          description: The Id of the device that should be connected.
           schema:
-            type: boolean
-            default: false
+            type: string
       responses:
         "200":
           description: Successful response
@@ -2008,7 +2202,7 @@ paths:
                 properties:
                   Response:
                     type: string
-                    example: Guider connected
+                    example: Connected
                   Error:
                     type: string
                     example: ""
@@ -2044,7 +2238,7 @@ paths:
                 properties:
                   Response:
                     type: string
-                    example: Guider disconnected
+                    example: Disconnected
                   Error:
                     type: string
                     example: ""
@@ -2057,6 +2251,46 @@ paths:
                   Type:
                     type: string
                     example: "API"
+        "500":
+          description: Internal server error, Unknown error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnknownError"
+
+  /equipment/guider/list-devices:
+    get:
+      tags:
+        - Guider
+      summary: List Devices
+      description: List all devices which can be connected
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeviceList"
+        "500":
+          description: Internal server error, Unknown error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnknownError"
+
+  /equipment/guider/rescan:
+    get:
+      tags:
+        - Guider
+      summary: Rescan Devices
+      description: Rescans for new devices, and returns a list of all available devices
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeviceList"
         "500":
           description: Internal server error, Unknown error
           content:
@@ -2293,12 +2527,11 @@ paths:
       description: Connect to Mount
       parameters:
         - in: query
-          name: skipRescan
+          name: to
           required: false
-          description: Indicates if rescan should be skipped
+          description: The Id of the device that should be connected.
           schema:
-            type: boolean
-            default: false
+            type: string
       responses:
         "200":
           description: Successful response
@@ -2309,7 +2542,7 @@ paths:
                 properties:
                   Response:
                     type: string
-                    example: Mount connected
+                    example: Connected
                   Error:
                     type: string
                     example: ""
@@ -2345,7 +2578,7 @@ paths:
                 properties:
                   Response:
                     type: string
-                    example: Mount disconnected
+                    example: Disconnected
                   Error:
                     type: string
                     example: ""
@@ -2358,6 +2591,46 @@ paths:
                   Type:
                     type: string
                     example: "API"
+        "500":
+          description: Internal server error, Unknown error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnknownError"
+
+  /equipment/mount/list-devices:
+    get:
+      tags:
+        - Mount
+      summary: List Devices
+      description: List all devices which can be connected
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeviceList"
+        "500":
+          description: Internal server error, Unknown error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnknownError"
+
+  /equipment/mount/rescan:
+    get:
+      tags:
+        - Mount
+      summary: Rescan Devices
+      description: Rescans for new devices, and returns a list of all available devices
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeviceList"
         "500":
           description: Internal server error, Unknown error
           content:
@@ -2913,12 +3186,11 @@ paths:
       description: Connect to Rotator
       parameters:
         - in: query
-          name: skipRescan
+          name: to
           required: false
-          description: Indicates if rescan should be skipped
+          description: The Id of the device that should be connected.
           schema:
-            type: boolean
-            default: false
+            type: string
       responses:
         "200":
           description: Successful response
@@ -2929,7 +3201,7 @@ paths:
                 properties:
                   Response:
                     type: string
-                    example: Rotator connected
+                    example: Connected
                   Error:
                     type: string
                     example: ""
@@ -2965,7 +3237,7 @@ paths:
                 properties:
                   Response:
                     type: string
-                    example: Rotator disconnected
+                    example: Disconnected
                   Error:
                     type: string
                     example: ""
@@ -2978,6 +3250,46 @@ paths:
                   Type:
                     type: string
                     example: "API"
+        "500":
+          description: Internal server error, Unknown error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnknownError"
+
+  /equipment/rotator/list-devices:
+    get:
+      tags:
+        - Rotator
+      summary: List Devices
+      description: List all devices which can be connected
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeviceList"
+        "500":
+          description: Internal server error, Unknown error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnknownError"
+
+  /equipment/rotator/rescan:
+    get:
+      tags:
+        - Rotator
+      summary: Rescan Devices
+      description: Rescans for new devices, and returns a list of all available devices
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeviceList"
         "500":
           description: Internal server error, Unknown error
           content:
@@ -3143,12 +3455,11 @@ paths:
       description: Connect to safety monitor
       parameters:
         - in: query
-          name: skipRescan
+          name: to
           required: false
-          description: Indicates if rescan should be skipped
+          description: The Id of the device that should be connected.
           schema:
-            type: boolean
-            default: false
+            type: string
       responses:
         "200":
           description: Successful response
@@ -3159,7 +3470,7 @@ paths:
                 properties:
                   Response:
                     type: string
-                    example: Safetymonitor connected
+                    example: Connected
                   Error:
                     type: string
                     example: ""
@@ -3195,7 +3506,7 @@ paths:
                 properties:
                   Response:
                     type: string
-                    example: Safetymonitor disconnected
+                    example: Disconnected
                   Error:
                     type: string
                     example: ""
@@ -3208,6 +3519,46 @@ paths:
                   Type:
                     type: string
                     example: "API"
+        "500":
+          description: Internal server error, Unknown error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnknownError"
+
+  /equipment/safetymonitor/list-devices:
+    get:
+      tags:
+        - Safety Monitor
+      summary: List Devices
+      description: List all devices which can be connected
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeviceList"
+        "500":
+          description: Internal server error, Unknown error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnknownError"
+
+  /equipment/safetymonitor/rescan:
+    get:
+      tags:
+        - Safety Monitor
+      summary: Rescan Devices
+      description: Rescans for new devices, and returns a list of all available devices
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeviceList"
         "500":
           description: Internal server error, Unknown error
           content:
@@ -3243,12 +3594,11 @@ paths:
       description: Connect to Switch
       parameters:
         - in: query
-          name: skipRescan
+          name: to
           required: false
-          description: Indicates if rescan should be skipped
+          description: The Id of the device that should be connected.
           schema:
-            type: boolean
-            default: false
+            type: string
       responses:
         "200":
           description: Successful response
@@ -3259,7 +3609,7 @@ paths:
                 properties:
                   Response:
                     type: string
-                    example: Switch connected
+                    example: Connected
                   Error:
                     type: string
                     example: ""
@@ -3295,7 +3645,7 @@ paths:
                 properties:
                   Response:
                     type: string
-                    example: Switch disconnected
+                    example: Disconnected
                   Error:
                     type: string
                     example: ""
@@ -3308,6 +3658,46 @@ paths:
                   Type:
                     type: string
                     example: "API"
+        "500":
+          description: Internal server error, Unknown error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnknownError"
+
+  /equipment/switch/list-devices:
+    get:
+      tags:
+        - Switch
+      summary: List Devices
+      description: List all devices which can be connected
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeviceList"
+        "500":
+          description: Internal server error, Unknown error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnknownError"
+
+  /equipment/switch/rescan:
+    get:
+      tags:
+        - Switch
+      summary: Rescan Devices
+      description: Rescans for new devices, and returns a list of all available devices
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeviceList"
         "500":
           description: Internal server error, Unknown error
           content:
@@ -3416,12 +3806,11 @@ paths:
       description: Connect to weather source
       parameters:
         - in: query
-          name: skipRescan
+          name: to
           required: false
-          description: Indicates if rescan should be skipped
+          description: The Id of the device that should be connected.
           schema:
-            type: boolean
-            default: false
+            type: string
       responses:
         "200":
           description: Successful response
@@ -3432,7 +3821,7 @@ paths:
                 properties:
                   Response:
                     type: string
-                    example: Weather connected
+                    example: Connected
                   Error:
                     type: string
                     example: ""
@@ -3468,7 +3857,7 @@ paths:
                 properties:
                   Response:
                     type: string
-                    example: Weather disconnected
+                    example: Disconnected
                   Error:
                     type: string
                     example: ""
@@ -3481,6 +3870,46 @@ paths:
                   Type:
                     type: string
                     example: "API"
+        "500":
+          description: Internal server error, Unknown error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnknownError"
+
+  /equipment/weather/list-devices:
+    get:
+      tags:
+        - Weather
+      summary: List Weather Sources
+      description: List all weather sources which can be connected
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeviceList"
+        "500":
+          description: Internal server error, Unknown error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnknownError"
+
+  /equipment/weather/rescan:
+    get:
+      tags:
+        - Weather
+      summary: Rescan Sources
+      description: Rescans for new weather sources, and returns a list of all available sources
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeviceList"
         "500":
           description: Internal server error, Unknown error
           content:
@@ -4571,8 +5000,8 @@ paths:
       tags:
         - Sequence
       summary: Edit a Sequence
-      description: 
-        This which works similary to profile/set-value. Note that this mainly supports fields that expect simple types like strings, numbers etc, 
+      description:
+        This which works similary to profile/set-value. Note that this mainly supports fields that expect simple types like strings, numbers etc,
         and may not work for things like enums or objects (filter, time source, ...). This is an experimental feature, and it could have unexpected side effects or simply not work for some instructions or fields.
         If you encounter any bugs (except that it is not working with enums or objects), feel free to create an issue on github or contact me on the NINA discord.
       responses:
@@ -8432,6 +8861,48 @@ components:
                     type: array
                     items: {}
 
+        Error:
+          type: string
+          example: ""
+        StatusCode:
+          type: integer
+          example: 200
+        Success:
+          type: boolean
+          example: true
+        Type:
+          type: string
+          example: "API"
+
+    DeviceList:
+      type: object
+      properties:
+        Response:
+          type: array
+          items:
+            type: object
+            properties:
+              HasSetupDialog:
+                type: boolean
+              Id:
+                type: string
+              Name:
+                type: string
+              DisplayName:
+                type: string
+              Category:
+                type: string
+              Connected:
+                type: boolean
+              Description:
+                type: string
+              DriverInfo:
+                type: string
+              DriverVersion:
+                type: string
+              SupportedActions:
+                type: array
+                items: {}
         Error:
           type: string
           example: ""

--- a/ninaAPI/app.config
+++ b/ninaAPI/app.config
@@ -95,6 +95,9 @@
       <setting name="UseAccessControlHeader" serializeAs="String">
         <value>False</value>
       </setting>
+      <setting name="CreateThumbnails" serializeAs="String">
+        <value>True</value>
+      </setting>
     </ninaAPI.Properties.Settings>
     <LensAF.Properties.Settings>
       <setting name="UpdateSettings" serializeAs="String">

--- a/ninaAPI/websocket_spec.yaml
+++ b/ninaAPI/websocket_spec.yaml
@@ -286,6 +286,8 @@ channels:
           enum:
             - start-alignment
             - stop-alignment
+            - pause-alignment
+            - resume-alignment
     subscribe:
       summary: Subscribe to TPPA WebSocket events
       operationId: onTPPAEvent
@@ -332,6 +334,8 @@ channels:
                   enum:
                     - "started procedure"
                     - "stopped procedure"
+                    - "paused procedure"
+                    - "resumed procedure"
                 Error:
                   type: string
                 StatusCode:

--- a/ninaAPI/websocket_spec.yaml
+++ b/ninaAPI/websocket_spec.yaml
@@ -1,7 +1,7 @@
 asyncapi: 2.0.0
 info:
   title: Advanced API
-  version: 2.1.8
+  version: 2.2.0.0
   description: This is the Websocket documentation for the NINA plugin Advanced API.
 servers:
   production:

--- a/ninaAPI/websocket_spec.yaml
+++ b/ninaAPI/websocket_spec.yaml
@@ -354,8 +354,7 @@ channels:
                 - Success
                 - Type
   /mount:
-    description:
-      A websocket channel to move the mount axis manually. This automatically stops all movement when the client disconnects as a safety measure to prevent any accidents.
+    description: A websocket channel to move the mount axis manually.
       You will need to resend the command to move the axis periodically about every second,
       because the server will automatically stop the movement when it hasn't recieved a command for two seconds as a safety measure.
     publish:


### PR DESCRIPTION
From now on, breaking changes will always increment the minor version number (the second number 2.x.0.0).
Sorry for the breaking changes, but they are worth it!

- ⚠️ **Breaking** Removed `skipRescan` from `{device}/connect`. This is now always true.
- ⚠️ **Breaking** The response formats of ``{device}/connect` and `{device}/disconnect` have changed. These now only return `Connected` or `Disconnected`.
- Added `to` to `{device}/connect` to specify which device should be connected. If omitted, the currently selected device will be used. This is the behavior as it was in the previous versions.
- Added `{device}/rescan` to rescan for new devices.
- Added `{device}/list-available` to list all available devices.

---

- ⚠️ **Breaking** The mount does not automatically stop the movement anymore when disconnecting. This was causing issues with PHD and the 2 second delay should be enough as a safety measure.
- Fixed an issue where the API would show the wrong ip address
- Added the url parameter `save` to the `camera/capture` endpoint. This will save the image to the disk. This needs to be set, when capturing the image.
- Added `sequence/state`, a new sequence endpoint for retrieving information that is much more elaborate and also supports plugins.
- Added `sequence/edit`, which works similary to `profile/set-value`. Note that this mainly supports fields that expect simple types like strings, numbers etc, and may not work for things like enums or objects (filter, time source, ...). This is an **experimental** feature and may be unreliable or uncomplete.
- Added `mount/set-park-position`, which sets the current mount position as park position.
- Added `pause-alignment` and `resume-alignment` to the TPPA WebSocket.
- Added an option to create and cache thumbnails for images. This has to be enabled if you want to use the new thumbnail endpoint (`image/thumbnail`).
- Introduced `camera/capture/statistics` which analyses the captured image and returns stats like HFR, Stars, Median, ...