### PR TITLE
Add an option to get the image as FITS

### DIFF
--- a/ninaAPI/WebService/V2/Application/Image.cs
+++ b/ninaAPI/WebService/V2/Application/Image.cs
@@ -308,22 +308,30 @@ namespace ninaAPI.WebService.V2
                     }
                     else
                     {
-                        // Create the FITS image.
-                        FITS f = new FITS(
-                            imageData.Data.FlatArray,
-                            imageData.Properties.Width,
-                            imageData.Properties.Height
-                        );
+                        // If the image is not of type FITS return an error.
+                        if (!p.GetPath().EndsWith(".fits", true, null))
+                        {
+                            response = CoreUtility.CreateErrorTable(new Error("Image is not a FITS file", 400));
+                        }
+                        else
+                        {
+                            // Create the FITS image.
+                            FITS f = new FITS(
+                                imageData.Data.FlatArray,
+                                imageData.Properties.Width,
+                                imageData.Properties.Height
+                            );
 
-                        f.PopulateHeaderCards(imageData.MetaData);
+                            f.PopulateHeaderCards(imageData.MetaData);
 
-                        // Populate the stream with the raw byte data of the FITS image.
-                        MemoryStream fits_stream = new MemoryStream();
+                            // Populate the stream with the raw byte data of the FITS image.
+                            MemoryStream fits_stream = new MemoryStream();
 
-                        f.Write(fits_stream);
+                            f.Write(fits_stream);
 
-                        // Encode the stream in base64 and send it.
-                        response.Response = Convert.ToBase64String(fits_stream.ToArray());
+                            // Encode the stream in base64 and send it.
+                            response.Response = Convert.ToBase64String(fits_stream.ToArray());
+                        }
                     }
                 }
             }

--- a/ninaAPI/api_spec.yaml
+++ b/ninaAPI/api_spec.yaml
@@ -4868,7 +4868,7 @@ paths:
               - SNAPSHOT
         - in: query
           name: raw_fits
-          description: Whether to send the raw data if the image is of type FITS.
+          description: Whether to send the image as a raw FITS format.
           required: false
           schema:
             type: boolean

--- a/ninaAPI/api_spec.yaml
+++ b/ninaAPI/api_spec.yaml
@@ -4866,6 +4866,12 @@ paths:
               - DARK
               - BIAS
               - SNAPSHOT
+        - in: query
+          name: raw_fits
+          description: Whether to send the raw data if the image is of type FITS.
+          required: false
+          schema:
+            type: boolean
       responses:
         "200":
           description: Successful response

--- a/ninaAPI/api_spec.yaml
+++ b/ninaAPI/api_spec.yaml
@@ -4868,7 +4868,7 @@ paths:
               - SNAPSHOT
         - in: query
           name: raw_fits
-          description: Whether to send the image as a raw FITS format.
+          description: Whether to send the image (without streaming) as a raw FITS format. Will return an error if the image is not of type FITS.
           required: false
           schema:
             type: boolean
@@ -4906,7 +4906,7 @@ paths:
                 type: array
                 format: binary
         "400":
-          description: Invalid image index / invalid bayer pattern
+          description: Invalid image index / invalid bayer pattern / image is not a FITS file
           content:
             application/json:
               schema:
@@ -4920,6 +4920,7 @@ paths:
                     enum:
                       - Index out of range
                       - Invalid bayer pattern
+                      - Image is not a FITS file
                   StatusCode:
                     type: integer
                     example: 400


### PR DESCRIPTION
This PR changes the /image/{index}/ endpoint, adding an additional query that returns the image in FITS format, encoded in base64.
