### PR TITLE
2.2.6.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,9 +4,11 @@ The changes for each individual (beta) release can be seen [here](https://github
 
 ## 2.2.6.0
 
+- CORS updates to support all HTTP verbs
 - Added `api/time` to get the current time, can be used to sync with other systems
 - Added `api/application-start` to get the application start date
 - Added `api/version/nina` to get the version of NINA
+- Added `api/application/logs` to get the last N log entries
 - Added `sequence/load` to load sequences into the advanced sequence
   - Use GET to load a sequence from the default sequence folder (you can use the `sequence/list-available` endpoint to get the available sequences)
   - Use POST to load a sequence from a json string, supplied by the client in the request body

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,9 @@ The changes for each individual (beta) release can be seen [here](https://github
 - Added `api/time` to get the current time, can be used to sync with other systems
 - Added `api/application-start` to get the application start date
 - Added `api/version/nina` to get the version of NINA
+- Added `sequence/load` to load sequences into the advanced sequence
+  - Use GET to load a sequence from the default sequence folder (you can use the `sequence/list-available` endpoint to get the available sequences)
+  - Use POST to load a sequence from a json string, supplied by the client in the request body
 
 ## 2.2.5.0
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,12 @@
 
 The changes for each individual (beta) release can be seen [here](https://github.com/christian-photo/ninaAPI/releases). However this Changelog will be mostly complete.
 
+## 2.2.6.0
+
+- Added `api/time` to get the current time, can be used to sync with other systems
+- Added `api/application-start` to get the application start date
+- Added `api/version/nina` to get the version of NINA
+
 ## 2.2.5.0
 
 - Added center + center and rotate to `mount/slew`, both can be stopped using `mount/slew/stop`

--- a/ninaAPI/Properties/AssemblyInfo.cs
+++ b/ninaAPI/Properties/AssemblyInfo.cs
@@ -6,8 +6,8 @@ using System.Runtime.InteropServices;
 
 // [MANDATORY] The assembly versioning
 //Should be incremented for each new build of a plugin
-[assembly: AssemblyVersion("2.2.5.0")]
-[assembly: AssemblyFileVersion("2.2.5.0")]
+[assembly: AssemblyVersion("2.2.6.0")]
+[assembly: AssemblyFileVersion("2.2.6.0")]
 
 // [MANDATORY] The name of your plugin
 [assembly: AssemblyTitle("Advanced API")]

--- a/ninaAPI/WebService/API.cs
+++ b/ninaAPI/WebService/API.cs
@@ -19,6 +19,7 @@ using ninaAPI.WebService.V2;
 using ninaAPI.WebService.V2.CustomDrivers;
 using System;
 using System.Collections.Generic;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -151,14 +152,21 @@ namespace ninaAPI.WebService
         {
         }
 
-        protected override Task OnRequestAsync(IHttpContext context)
+        protected override async Task OnRequestAsync(IHttpContext context)
         {
             Logger.Trace($"Request: {context.Request.Url.OriginalString}");
             if (Settings.Default.UseAccessControlHeader)
             {
                 context.Response.Headers.Add("Access-Control-Allow-Origin", "*");
+                context.Response.Headers.Add("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
+                context.Response.Headers.Add("Access-Control-Allow-Headers", "Content-Type, Authorization");
+
+                if (context.Request.HttpVerb == HttpVerbs.Options)
+                {
+                    context.Response.StatusCode = 200;
+                    await context.SendStringAsync(string.Empty, "text/plain", Encoding.UTF8);
+                }
             }
-            return Task.CompletedTask;
         }
 
         public override bool IsFinalHandler => false;

--- a/ninaAPI/WebService/V2/ControllerV2.cs
+++ b/ninaAPI/WebService/V2/ControllerV2.cs
@@ -9,6 +9,8 @@
 
 #endregion "copyright"
 
+using System;
+using System.Globalization;
 using System.Reflection;
 using EmbedIO;
 using EmbedIO.Routing;
@@ -29,6 +31,24 @@ namespace ninaAPI.WebService.V2
         public void GetVersion()
         {
             HttpContext.WriteToResponse(new HttpResponse() { Response = Assembly.GetAssembly(typeof(AdvancedAPI)).GetName().Version.ToString() });
+        }
+
+        [Route(HttpVerbs.Get, "/time")]
+        public void GetTime()
+        {
+            HttpContext.WriteToResponse(new HttpResponse() { Response = DateTime.Now });
+        }
+
+        [Route(HttpVerbs.Get, "/application-start")]
+        public void GetApplicationStart()
+        {
+            HttpContext.WriteToResponse(new HttpResponse() { Response = NINA.Core.Utility.CoreUtil.ApplicationStartDate });
+        }
+
+        [Route(HttpVerbs.Get, "/version/nina")]
+        public void GetNINAVersion([QueryField] bool friendly)
+        {
+            HttpContext.WriteToResponse(new HttpResponse() { Response = friendly ? NINA.Core.Utility.CoreUtil.VersionFriendlyName : NINA.Core.Utility.CoreUtil.Version });
         }
     }
 }

--- a/ninaAPI/api_spec.yaml
+++ b/ninaAPI/api_spec.yaml
@@ -37,6 +37,76 @@ paths:
                     type: string
                     example: "API"
 
+  /version/nina:
+    get:
+      tags:
+        - Application
+      summary: NINA Version
+      description: Returns the version of NINA.
+      parameters:
+        - in: query
+          name: friendly
+          required: false
+          description: If true, the version will be returned in a friendly format.
+          schema:
+            type: boolean
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  Response:
+                    type: string
+                    example:
+                      oneOf:
+                        - 3.2.0.1058
+                        - "3.2 NIGHTLY #058"
+                  Error:
+                    type: string
+                    example: ""
+                  StatusCode:
+                    type: integer
+                    example: 200
+                  Success:
+                    type: boolean
+                    example: true
+                  Type:
+                    type: string
+                    example: "API"
+
+  /application-start:
+    get:
+      tags:
+        - Application
+      summary: NINA start time
+      description: Returns the time NINA was started.
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  Response:
+                    type: string
+                    example: 2025-07-20T09:43:44.351798+02:00
+                  Error:
+                    type: string
+                    example: ""
+                  StatusCode:
+                    type: integer
+                    example: 200
+                  Success:
+                    type: boolean
+                    example: true
+                  Type:
+                    type: string
+                    example: "API"
+
   /equipment/camera/info:
     get:
       tags:

--- a/ninaAPI/api_spec.yaml
+++ b/ninaAPI/api_spec.yaml
@@ -1,8 +1,8 @@
 openapi: 3.0.0
 info:
   title: Advanced API
-  description: This is the API documentation for the NINA plugin Advanced API. This documentation applies to plugin version 2.2.2.*
-  version: 2.2.5
+  description: This is the API documentation for the NINA plugin Advanced API.
+  version: 2.2.6
 servers:
   - url: http://localhost:1888/v2/api
     description: V2 api server
@@ -23,7 +23,7 @@ paths:
                 properties:
                   Response:
                     type: string
-                    example: 2.2.5.0
+                    example: 2.2.6.0
                   Error:
                     type: string
                     example: ""
@@ -4509,6 +4509,60 @@ paths:
                         "Three Point Polar Alignment",
                         "Touch 'N' Stars",
                       ]
+                  Error:
+                    type: string
+                    example: ""
+                  StatusCode:
+                    type: integer
+                    example: 200
+                  Success:
+                    type: boolean
+                    example: true
+                  Type:
+                    type: string
+                    example: "API"
+        "500":
+          description: Internal server error, Unknown error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnknownError"
+
+  /application/logs:
+    get:
+      tags:
+        - Application
+      summary: Logs
+      description: Get a list of the last N log entries, this will ignore the header of the file
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  Response:
+                    type: object
+                    properties:
+                      Timestamp:
+                        type: string
+                        example: "2025-05-04T14:57:39.5079"
+                      Level:
+                        type: string
+                        example: "INFO"
+                      Source:
+                        type: string
+                        example: "CameraChooserVM.cs"
+                      Member:
+                        type: string
+                        example: "GetEquipment"
+                      Line:
+                        type: string
+                        example: "279"
+                      Message:
+                        type: string
+                        example: "Found 2 ASCOM Cameras"
                   Error:
                     type: string
                     example: ""

--- a/ninaAPI/api_spec.yaml
+++ b/ninaAPI/api_spec.yaml
@@ -6036,6 +6036,132 @@ paths:
               schema:
                 $ref: "#/components/schemas/UnknownError"
 
+  /sequence/load:
+    get:
+      tags:
+        - Sequence
+      summary: Load Sequence from file
+      description: Loads a sequence from a file from the default sequence folders, the names can be retrieved using the `sequence/list-available` endpoint
+      parameters:
+        - name: sequenceName
+          in: query
+          description: The name of the sequence to load
+          required: true
+          schema:
+            type: string
+            example: Orion
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  Response:
+                    type: string
+                    example: Sequence updated
+                  Error:
+                    type: string
+                    example: ""
+                  StatusCode:
+                    type: integer
+                    example: 200
+                  Success:
+                    type: boolean
+                    example: true
+                  Type:
+                    type: string
+                    example: "API"
+        "400":
+          description: Sequence not initialized or already running
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  Response:
+                    type: string
+                    example: ""
+                  Error:
+                    type: string
+                    enum:
+                      - Sequence is not initialized
+                      - Sequence is already running
+                  StatusCode:
+                    type: integer
+                    example: 400
+                  Success:
+                    type: boolean
+                    example: false
+                  Type:
+                    type: string
+                    example: "API"
+        "500":
+          description: Internal Server Error, Unknown Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnknownError"
+    post:
+      tags:
+        - Sequence
+      summary: Load Sequence from JSON
+      description: Loads a sequence from a JSON supplied by the client in the request body
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  Response:
+                    type: string
+                    example: Sequence updated
+                  Error:
+                    type: string
+                    example: ""
+                  StatusCode:
+                    type: integer
+                    example: 200
+                  Success:
+                    type: boolean
+                    example: true
+                  Type:
+                    type: string
+                    example: "API"
+        "400":
+          description: Sequence not initialized or already running
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  Response:
+                    type: string
+                    example: ""
+                  Error:
+                    type: string
+                    enum:
+                      - Sequence is not initialized
+                      - Sequence is already running
+                  StatusCode:
+                    type: integer
+                    example: 400
+                  Success:
+                    type: boolean
+                    example: false
+                  Type:
+                    type: string
+                    example: "API"
+        "500":
+          description: Internal Server Error, Unknown Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnknownError"
+
   /event-history:
     get:
       tags:


### PR DESCRIPTION
- CORS updates to support all HTTP verbs
- Added `api/time` to get the current time, can be used to sync with other systems
- Added `api/application-start` to get the application start date
- Added `api/version/nina` to get the version of NINA
- Added `api/application/logs` to get the last N log entries
- Added `sequence/load` to load sequences into the advanced sequence
  - Use GET to load a sequence from the default sequence folder (you can use the `sequence/list-available` endpoint to get the available sequences)
  - Use POST to load a sequence from a json string, supplied by the client in the request body