### PR TITLE
adds a filename property to the image response

### DIFF
--- a/ninaAPI/WebService/V2/Application/Image.cs
+++ b/ninaAPI/WebService/V2/Application/Image.cs
@@ -54,6 +54,7 @@ namespace ninaAPI.WebService.V2
         public double HFR { get; set; }
         public double HFRStDev { get; set; }
         public bool IsBayered { get; set; }
+        public string Filename { get => Path?.IsFile == true ? System.IO.Path.GetFileName(Path.LocalPath) : null; }
 
         private Uri Path { get; set; }
 


### PR DESCRIPTION
This pull request introduces a small enhancement to the `ImageResponse` class in the image API. The change adds a convenient property to retrieve the filename from the image path if available.

* Added a read-only `Filename` property to `ImageResponse` that returns the filename from the local path when `Path` is a file, improving accessibility to image metadata.