### PR TITLE
2.2.14.4

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,13 @@
 
 The changes for each individual (beta) release can be seen in each [release](https://github.com/christian-photo/ninaAPI/releases). This changelog will only cover the fully released versions.
 
+## 2.2.14.4
+
+- Add camera USB limit api endpoint
+- Add snapshot mode for normal images and snapshots
+  - `equipment/camera/set-readout/image`
+  - `equipment/camera/set-readout/snapshot`
+
 ## 2.2.14.3
 
 - Add rotator stop move api endpoint

--- a/ninaAPI/Properties/AssemblyInfo.cs
+++ b/ninaAPI/Properties/AssemblyInfo.cs
@@ -6,8 +6,8 @@ using System.Runtime.InteropServices;
 
 // [MANDATORY] The assembly versioning
 //Should be incremented for each new build of a plugin
-[assembly: AssemblyVersion("2.2.14.3")]
-[assembly: AssemblyFileVersion("2.2.14.3")]
+[assembly: AssemblyVersion("2.2.14.4")]
+[assembly: AssemblyFileVersion("2.2.14.4")]
 
 // [MANDATORY] The name of your plugin
 [assembly: AssemblyTitle("Advanced API")]
@@ -18,7 +18,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCompany("Christian Palm")]
 // The product name that this plugin is part of
 [assembly: AssemblyProduct("Advanced API")]
-[assembly: AssemblyCopyright("Copyright ©  2025")]
+[assembly: AssemblyCopyright("Copyright ©  2026")]
 
 // The minimum Version of N.I.N.A. that this plugin is compatible with
 [assembly: AssemblyMetadata("MinimumApplicationVersion", "3.2.0.9001")]

--- a/ninaAPI/WebService/V2/Equipment/Camera.cs
+++ b/ninaAPI/WebService/V2/Equipment/Camera.cs
@@ -36,6 +36,7 @@ using NINA.Image.ImageAnalysis;
 using NINA.Core.Enum;
 using System.Reflection;
 using Accord;
+using NINA.Equipment.Interfaces;
 
 namespace ninaAPI.WebService.V2
 {
@@ -213,6 +214,62 @@ namespace ninaAPI.WebService.V2
             HttpContext.WriteToResponse(response);
         }
 
+        [Route(HttpVerbs.Get, "/equipment/camera/set-readout/image")]
+        public void CameraSetReadoutImage([QueryField] short mode)
+        {
+            HttpResponse response = new HttpResponse();
+
+            try
+            {
+                ICameraMediator cam = AdvancedAPI.Controls.Camera;
+
+                if (mode >= 0 && mode < cam.GetInfo().ReadoutModes.Count())
+                {
+                    ((ICamera)cam.GetDevice()).ReadoutModeForNormalImages = mode;
+                    response.Response = "Readout mode updated";
+                }
+                else
+                {
+                    response = CoreUtility.CreateErrorTable(new Error("Invalid readout mode", 400));
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex);
+                response = CoreUtility.CreateErrorTable(CommonErrors.UNKNOWN_ERROR);
+            }
+
+            HttpContext.WriteToResponse(response);
+        }
+
+        [Route(HttpVerbs.Get, "/equipment/camera/set-readout/snapshot")]
+        public void CameraSetReadoutSnapshot([QueryField] short mode)
+        {
+            HttpResponse response = new HttpResponse();
+
+            try
+            {
+                ICameraMediator cam = AdvancedAPI.Controls.Camera;
+
+                if (mode >= 0 && mode < cam.GetInfo().ReadoutModes.Count())
+                {
+                    ((ICamera)cam.GetDevice()).ReadoutModeForSnapImages = mode;
+                    response.Response = "Readout mode updated";
+                }
+                else
+                {
+                    response = CoreUtility.CreateErrorTable(new Error("Invalid readout mode", 400));
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex);
+                response = CoreUtility.CreateErrorTable(CommonErrors.UNKNOWN_ERROR);
+            }
+
+            HttpContext.WriteToResponse(response);
+        }
+
         [Route(HttpVerbs.Get, "/equipment/camera/cool")]
         public void CameraCool([QueryField] double temperature, [QueryField] bool cancel, [QueryField] double minutes)
         {
@@ -350,6 +407,42 @@ namespace ninaAPI.WebService.V2
                 {
                     cam.SetDewHeater(power);
                     response.Response = "Dew heater set";
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex);
+                response = CoreUtility.CreateErrorTable(CommonErrors.UNKNOWN_ERROR);
+            }
+
+            HttpContext.WriteToResponse(response);
+        }
+
+        [Route(HttpVerbs.Get, "/equipment/camera/usb-limit")]
+        public void CameraDewHeater([QueryField] int limit)
+        {
+            HttpResponse response = new HttpResponse();
+
+            try
+            {
+                ICameraMediator cam = AdvancedAPI.Controls.Camera;
+
+                if (!cam.GetInfo().Connected)
+                {
+                    response = CoreUtility.CreateErrorTable(new Error("Camera not connected", 409));
+                }
+                else if (!cam.GetInfo().CanSetUSBLimit)
+                {
+                    response = CoreUtility.CreateErrorTable(new Error("Camera can not set USB limit", 409));
+                }
+                else if (limit < cam.GetInfo().USBLimitMin || limit > cam.GetInfo().USBLimitMax)
+                {
+                    response = CoreUtility.CreateErrorTable(new Error("USB limit out of range", 409));
+                }
+                else
+                {
+                    cam.SetUSBLimit(limit);
+                    response.Response = "USB limit set";
                 }
             }
             catch (Exception ex)

--- a/ninaAPI/api_spec.yaml
+++ b/ninaAPI/api_spec.yaml
@@ -339,6 +339,138 @@ paths:
               schema:
                 $ref: "#/components/schemas/UnknownError"
 
+  /equipment/camera/set-readout/image:
+    get:
+      tags:
+        - Camera
+      summary: Set readout mode for normal images
+      description: This endpoint sets the readout mode for normal images.
+      parameters:
+        - in: query
+          name: mode
+          description: The readout mode to set.
+          schema:
+            type: integer
+            minimum: 0
+          required: true
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  Response:
+                    type: string
+                    example: Readout mode updated
+                  Error:
+                    type: string
+                    example: ""
+                  StatusCode:
+                    type: integer
+                    example: 200
+                  Success:
+                    type: boolean
+                    example: true
+                  Type:
+                    type: string
+                    example: "API"
+        "400":
+          description: Invalid readout mode
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  Response:
+                    type: string
+                    example: ""
+                  Error:
+                    type: string
+                    example: Invalid readout mode
+                  StatusCode:
+                    type: integer
+                    example: 409
+                  Success:
+                    type: boolean
+                    example: false
+                  Type:
+                    type: string
+                    example: "API"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnknownError"
+
+  /equipment/camera/set-readout/snapshot:
+    get:
+      tags:
+        - Camera
+      summary: Set readout mode for snapshots
+      description: This endpoint sets the readout mode for snapshots.
+      parameters:
+        - in: query
+          name: mode
+          description: The readout mode to set.
+          schema:
+            type: integer
+            minimum: 0
+          required: true
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  Response:
+                    type: string
+                    example: Readout mode updated
+                  Error:
+                    type: string
+                    example: ""
+                  StatusCode:
+                    type: integer
+                    example: 200
+                  Success:
+                    type: boolean
+                    example: true
+                  Type:
+                    type: string
+                    example: "API"
+        "400":
+          description: Invalid readout mode
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  Response:
+                    type: string
+                    example: ""
+                  Error:
+                    type: string
+                    example: Invalid readout mode
+                  StatusCode:
+                    type: integer
+                    example: 409
+                  Success:
+                    type: boolean
+                    example: false
+                  Type:
+                    type: string
+                    example: "API"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnknownError"
+
   /equipment/camera/cool:
     get:
       tags:
@@ -611,6 +743,75 @@ paths:
                     enum:
                       - Camera not connected
                       - Camera has no dew heater
+                  StatusCode:
+                    type: integer
+                    example: 409
+                  Success:
+                    type: boolean
+                    example: false
+                  Type:
+                    type: string
+                    example: "API"
+        "500":
+          description: Internal server error, Unknown error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnknownError"
+
+  /equipment/camera/usb-limit:
+    get:
+      tags:
+        - Camera
+      summary: Set USB limit
+      description: This endpoint sets the usb limit of the camera
+      parameters:
+        - in: query
+          name: limit
+          description: The USB limit. Has to be between USBLimitMin and USBLimitMax.
+          required: true
+          schema:
+            type: string
+            example: 2x2
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  Response:
+                    type: string
+                    example: USB limit set
+                  Error:
+                    type: string
+                    example: ""
+                  StatusCode:
+                    type: integer
+                    example: 200
+                  Success:
+                    type: boolean
+                    example: true
+                  Type:
+                    type: string
+                    example: "API"
+        "409":
+          description: Camera not connected / USB limit cant be set
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  Response:
+                    type: string
+                    example: ""
+                  Error:
+                    type: string
+                    enum:
+                      - Camera not connected
+                      - Camera can not set USB limit
+                      - USB limit out of range
                   StatusCode:
                     type: integer
                     example: 409


### PR DESCRIPTION
- Add camera USB limit api endpoint
- Add snapshot mode for normal images and snapshots
  - `equipment/camera/set-readout/image`
  - `equipment/camera/set-readout/snapshot`
